### PR TITLE
refactor: simplify resolve_typst_bin() by removing pcall wrapper

### DIFF
--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -70,9 +70,9 @@ local function resolve_typst_bin()
   end
   typst_checked = true
 
-  local ok, paths = pcall(function() return quarto.paths.typst() end)
-  if ok and paths and paths ~= '' then
-    typst_bin = paths
+  local path = quarto.paths.typst()
+  if path and path ~= '' then
+    typst_bin = path
     return typst_bin
   end
 


### PR DESCRIPTION
## Summary

- Remove unnecessary `pcall` wrapper around `quarto.paths.typst()` since the extension requires Quarto >= 1.6.0 which guarantees its availability.