### PR TITLE
feat: add classes option and forward unknown options as HTML attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- feat: add `classes` option for CSS classes on output image elements.
+- feat: add `img-fluid` class by default for responsive images in HTML output.
+- feat: forward unknown code-cell options as HTML attributes on the output image element.
+
 ## 0.3.0 (2026-03-09)
 
 ### New Features

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -61,6 +61,9 @@ options:
     type: string
     enum: [fragment, slide, column, column-fragment]
     description: "Output placement in Reveal.js presentations. Ignored for other formats."
+  classes:
+    type: string
+    description: "Space-separated CSS classes applied to the output image element (e.g., 'r-stretch')."
 
 # Per-block comment+pipe attributes (//| key: value).
 # These are parsed from the code block text, not from element attributes.
@@ -117,6 +120,9 @@ attributes:
       type: string
       enum: [fragment, slide, column, column-fragment]
       description: "Output placement in Reveal.js presentations. Ignored for other formats."
+    classes:
+      type: string
+      description: "Space-separated CSS classes applied to the output image element (e.g., 'r-stretch')."
     label:
       type: string
       description: "Cross-reference label (e.g., 'fig-my-diagram', 'tbl-results')."

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -40,8 +40,26 @@ local DEFAULTS = {
   include = true,
   output = true,
   ['output-location'] = nil,
+  classes = nil,
   label = nil,
 }
+
+--- Keys consumed by the filter; any other option is forwarded as an HTML attribute.
+local KNOWN_KEYS = { cap = true, alt = true }
+for k in pairs(DEFAULTS) do
+  KNOWN_KEYS[k] = true
+end
+
+--- Check whether a key is consumed by the filter (not forwarded as an attribute).
+--- Matches exact known keys and prefix-specific cross-ref keys (e.g. fig-cap, tbl-alt).
+--- @param key string
+--- @return boolean
+local function is_known_key(key)
+  if KNOWN_KEYS[key] then
+    return true
+  end
+  return key:match('^%a+%-cap$') ~= nil or key:match('^%a+%-alt$') ~= nil
+end
 
 --- Cache subdirectory within the .quarto scratch directory
 local CACHE_SUBDIR = '.quarto/typst-render'
@@ -283,11 +301,28 @@ local function create_image_element(img_path, opts)
   local caption_text = cell.resolve_caption(opts)
   local alt_text = cell.resolve_alt(opts, caption_text)
 
+  local classes = {}
+  if quarto.format.is_html_output() then
+    classes[#classes + 1] = 'img-fluid'
+  end
+  if type(opts.classes) == 'string' and opts.classes ~= '' then
+    for cls in opts.classes:gmatch('%S+') do
+      classes[#classes + 1] = cls
+    end
+  end
+
+  local kvpairs = {}
+  for k, v in pairs(opts) do
+    if not is_known_key(k) and type(v) == 'string' then
+      kvpairs[#kvpairs + 1] = { k, v }
+    end
+  end
+
   local img = pandoc.Image(
     { pandoc.Str(alt_text) },
     img_path,
     '',
-    pandoc.Attr('', {}, {})
+    pandoc.Attr('', classes, kvpairs)
   )
 
   return pandoc.Para({ img })
@@ -353,7 +388,7 @@ local function get_configuration(meta)
     -- so we use a separate key list to ensure 'format' etc. are not missed.
     local config_keys = {
       'format', 'dpi', 'width', 'height', 'margin', 'background',
-      'preamble', 'cache', 'echo', 'eval', 'include', 'output', 'output-location',
+      'preamble', 'cache', 'echo', 'eval', 'include', 'output', 'output-location', 'classes',
     }
     for _, k in ipairs(config_keys) do
       local default_val = DEFAULTS[k]

--- a/example.qmd
+++ b/example.qmd
@@ -480,6 +480,10 @@ extensions:
 | `eval`       | boolean         | `true`    | Compile Typst code to image.                                         |
 | `include`    | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.           |
 | `output`     | boolean         | `true`    | Show rendered output. Set `false` to skip compilation.               |
+| `classes`    | string          | (none)    | Space-separated CSS classes on the output image (e.g., `r-stretch`). |
+
+Any unknown option with a string value is forwarded as an HTML attribute on the output image element (e.g., `//| style: "max-height: 300px;"`).
+Values that look like booleans (`true`/`false`) must be quoted to be forwarded (e.g., `//| data-lazy: "true"`).
 
 ### Per-Block Cross-Referencing Options
 


### PR DESCRIPTION
Add a `classes` option for applying CSS classes to output image elements (e.g., `r-stretch` for Reveal.js).
Add `img-fluid` by default on HTML outputs for responsive images.
Forward any unknown code-cell option as an HTML attribute on the image element, allowing inline styles and data attributes without filter changes.