### PR TITLE
fix: use numeric type for dpi option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Use numeric type for `dpi` option instead of string.
+
 ## 0.9.0 (2026-03-23)
 
 ### Refactoring

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Inline preamble:
 ```yaml
 extensions:
   typst-render:
-    dpi: "288"
+    dpi: 288
     margin: "1em"
     preamble: '#set text(font: "Libertinus Serif")'
 ```
@@ -272,7 +272,7 @@ Per-block input override using comma-separated syntax:
 | Option            | Type            | Default   | Description                                                                                   |
 | ----------------- | --------------- | --------- | --------------------------------------------------------------------------------------------- |
 | `format`          | string          | (auto)    | Image format: `png`, `svg`, `pdf`.                                                            |
-| `dpi`             | string          | `"144"`   | Pixels per inch (PNG only).                                                                   |
+| `dpi`             | number          | `144`     | Pixels per inch (PNG only).                                                                   |
 | `width`           | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                               |
 | `height`          | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                              |
 | `margin`          | string          | `"0.5em"` | Page margin for image compilation; block `inset` with `output: asis`.                         |

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -10,8 +10,8 @@ options:
     enum: [png, svg, pdf]
     description: "Image output format. Auto-detected from output format if not set."
   dpi:
-    type: string
-    default: "144"
+    type: number
+    default: 144
     description: "Pixels per inch for PNG output."
   width:
     type: string
@@ -128,7 +128,7 @@ attributes:
       enum: [png, svg, pdf]
       description: "Image output format for this block."
     dpi:
-      type: string
+      type: number
       description: "Pixels per inch for PNG output."
     width:
       type: string

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -600,7 +600,7 @@ local function compile_typst(source, opts, img_format)
     )
     dpi = DEFAULTS.dpi
   end
-  dpi = tostring(dpi)
+  dpi = tostring(math.floor(dpi))
 
   -- Merge global and per-block input variables
   local merged_input = merge_inputs(opts.input, opts._block_input)

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -33,7 +33,7 @@ local VALID_ALIGN_SET = { left = true, center = true, right = true, default = tr
 --- Default option values
 local DEFAULTS = {
   format = nil,
-  dpi = '144',
+  dpi = 144,
   width = 'auto',
   height = 'auto',
   margin = '0.5em',
@@ -592,14 +592,15 @@ local function compile_typst(source, opts, img_format)
     return nil
   end
 
-  local dpi = tostring(opts.dpi)
-  if not dpi:match('^%d+$') or tonumber(dpi) <= 0 then
+  local dpi = tonumber(opts.dpi)
+  if not dpi or dpi <= 0 or dpi ~= math.floor(dpi) then
     log.log_warning(
       EXTENSION_NAME,
-      'Invalid dpi value "' .. dpi .. '"; falling back to default (' .. DEFAULTS.dpi .. ').'
+      'Invalid dpi value "' .. tostring(opts.dpi) .. '"; falling back to default (' .. DEFAULTS.dpi .. ').'
     )
     dpi = DEFAULTS.dpi
   end
+  dpi = tostring(dpi)
 
   -- Merge global and per-block input variables
   local merged_input = merge_inputs(opts.input, opts._block_input)
@@ -979,6 +980,11 @@ local function get_configuration(meta)
             else
               global_config[k] = str == 'true'
             end
+          end
+        elseif type(default_val) == 'number' then
+          local n = tonumber(pandoc.utils.stringify(val))
+          if n then
+            global_config[k] = n
           end
         elseif type(default_val) == 'boolean' then
           if type(val) == 'boolean' then

--- a/example.qmd
+++ b/example.qmd
@@ -560,7 +560,7 @@ See [Global-Only Options](#global-only-options) for options that cannot be overr
 ```yaml
 extensions:
   typst-render:
-    dpi: "288"
+    dpi: 288
     margin: "1em"
     format: png
     cache: true
@@ -571,7 +571,7 @@ extensions:
 | Option            | Type            | Default   | Description                                                                       |
 | ----------------- | --------------- | --------- | --------------------------------------------------------------------------------- |
 | `format`          | string          | (auto)    | Image format: `png`, `svg`, `pdf`.                                                |
-| `dpi`             | string          | `"144"`   | Pixels per inch (PNG only).                                                       |
+| `dpi`             | number          | `144`     | Pixels per inch (PNG only).                                                       |
 | `width`           | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                   |
 | `height`          | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                  |
 | `margin`          | string          | `"0.5em"` | Page margin for image compilation; block `inset` with `output: asis`.             |


### PR DESCRIPTION
The `dpi` option stores pixels per inch but was defined as a string throughout the codebase.
Changed the default, schema, config reader, and validation to use a numeric type.
The value is converted to string only when passed to the Typst CLI `--ppi` flag and cache hashing.
Uses `math.floor()` during string conversion to prevent trailing `.0` from float inputs.
Updated documentation tables and YAML examples in `README.md` and `example.qmd`.