### PR TITLE
feat: add output-directory and output-filename options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.luarc.json
 /.quarto/
+/_output/
 *.html
 *.pdf
 *.docx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: add `output-directory` and `output-filename` options to save compiled images to user-specified locations.
+
 ## 0.9.3 (2026-04-15)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Inline maths: `{typst} $ x^2 + y^2 = z^2 $` renders as a formula image.
 ```
 
 Global options (`format`, `dpi`, `preamble`, `background`, `foreground`, `output`) apply to inline expressions.
-Block-only options (`echo`, `eval`, `label`, `cap`, `alt`, `file`, `pages`, `layout-ncol`, `output-location`) are not available for inline expressions.
+Block-only options (`echo`, `eval`, `label`, `cap`, `alt`, `file`, `output-filename`, `pages`, `layout-ncol`, `output-location`) are not available for inline expressions.
 
 Provide explicit alt text for accessibility using the `alt` attribute:
 
@@ -211,6 +211,48 @@ extensions:
     cache: clean
 ```
 
+### Output Directory
+
+By default, compiled images are only stored in the internal cache directory (`.quarto/typst-render/`) with auto-generated filenames.
+Set `output-directory` to also save copies to a predictable location, and optionally override the filename per block with `output-filename`.
+
+Paths follow Quarto conventions: a leading `/` is relative to the project root, otherwise relative to the document directory.
+
+Global directory (all blocks are saved automatically):
+
+```yaml
+extensions:
+  typst-render:
+    output-directory: /images/typst/
+```
+
+When `output-directory` is set and no `output-filename` is given, the filename is auto-generated from the block label (e.g., `fig-diagram.png`) or block counter (e.g., `typst-block-1.png`).
+
+Per-block filename override:
+
+````markdown
+```{typst}
+//| output-filename: my-diagram.png
+#circle(radius: 1cm, fill: blue)
+```
+````
+
+Combined usage:
+
+````markdown
+```{typst}
+//| label: fig-chart
+//| output-filename: chart.svg
+#rect(width: 3cm, height: 2cm, fill: eastern)
+```
+````
+
+With a global `output-directory: /images/`, this saves to `/images/chart.svg` (project root).
+A per-block `output-filename` starting with `/` overrides the global directory entirely (e.g., `//| output-filename: /other/result.png` saves to `/other/result.png`).
+
+For multi-page output, page numbers are appended before the extension (e.g., `diagram1.png`, `diagram2.png`).
+For dual-mode (light/dark) rendering, `-light` and `-dark` suffixes are appended (e.g., `diagram-light.svg`, `diagram-dark.svg`).
+
 ### Foreground and Background Colours
 
 Set text and page fill colours for rendered images.
@@ -282,6 +324,8 @@ Per-block input override using comma-separated syntax:
 | `cache`           | boolean\|string | `true`    | Cache compiled images. Use `"clean"` to also remove stale cache files.                        |
 | `input`           | object          | (none)    | Key-value pairs passed as `--input` flags to Typst CLI.                                       |
 | `file`            | string          | (none)    | Path to external `.typ` file to render.                                                       |
+| `output-directory` | string         | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).               |
+| `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted. |
 | `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).                          |
 | `eval`            | boolean         | `true`    | Compile Typst code to image.                                                                  |
 | `include`         | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                                    |

--- a/_extensions/typst-render/_modules/logging.lua
+++ b/_extensions/typst-render/_modules/logging.lua
@@ -44,6 +44,19 @@ function M.log_output(extension_name, message)
   quarto.log.output('[' .. extension_name .. '] ' .. message)
 end
 
+--- Format and log a debug message with extension prefix.
+--- Only emits output when QUARTO_LOG_LEVEL is DEBUG.
+---
+--- @param extension_name string The name of the extension
+--- @param message string The debug message to display
+--- @usage M.log_debug("typst-render", "Saved image to /path/to/file.png")
+function M.log_debug(extension_name, message)
+  local level = os.getenv('QUARTO_LOG_LEVEL')
+  if level and level:upper() == 'DEBUG' then
+    quarto.log.output('(D) [' .. extension_name .. '] ' .. message)
+  end
+end
+
 -- ============================================================================
 -- MODULE EXPORT
 -- ============================================================================

--- a/_extensions/typst-render/_modules/logging.lua
+++ b/_extensions/typst-render/_modules/logging.lua
@@ -45,16 +45,14 @@ function M.log_output(extension_name, message)
 end
 
 --- Format and log a debug message with extension prefix.
---- Only emits output when QUARTO_LOG_LEVEL is DEBUG.
+--- Provides standardised debug messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
 ---
---- @param extension_name string The name of the extension
+--- @param extension_name string The name of the extension (e.g., "lua-env")
 --- @param message string The debug message to display
---- @usage M.log_debug("typst-render", "Saved image to /path/to/file.png")
+--- @usage M.log_debug("lua-env", "Variable 'x' has value: 42")
 function M.log_debug(extension_name, message)
-  local level = os.getenv('QUARTO_LOG_LEVEL')
-  if level and level:upper() == 'DEBUG' then
-    quarto.log.output('(D) [' .. extension_name .. '] ' .. message)
-  end
+  quarto.log.debug('[' .. extension_name .. '] ' .. message)
 end
 
 -- ============================================================================

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -118,6 +118,11 @@ options:
     type: string
     enum: [left, center, right, default]
     description: "Horizontal alignment for the rendered image block."
+  output-directory:
+    type: string
+    description: "Default output directory for saving compiled images. Per-block output-filename paths are resolved relative to this directory."
+    completion:
+      type: directory
 
 # Per-block comment+pipe attributes (//| key: value).
 # These are parsed from the code block text, not from element attributes.
@@ -163,6 +168,17 @@ attributes:
       completion:
         type: file
         extensions: [.typ]
+    output-directory:
+      type: string
+      description: "Output directory for this block, overrides the global output-directory."
+      completion:
+        type: directory
+    output-filename:
+      type: string
+      description: "Path to save the compiled image. Leading '/' means project root (ignores output-directory). Otherwise resolved relative to output-directory. Auto-generated from label or block counter if omitted."
+      completion:
+        type: file
+        extensions: [.png, .svg, .pdf]
     echo:
       type: [boolean, string]
       enum: [true, false, fenced]

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -42,6 +42,8 @@ local DEFAULTS = {
   preamble = '',
   cache = true,
   file = nil,
+  ['output-directory'] = nil,
+  ['output-filename'] = nil,
   input = nil,
   echo = false,
   eval = true,
@@ -71,6 +73,8 @@ local KNOWN_KEYS = {
   format = true,
   foreground = true,
   file = true,
+  ['output-directory'] = true,
+  ['output-filename'] = true,
   input = true,
   ['output-location'] = true,
   classes = true,
@@ -584,6 +588,185 @@ local function discover_page_files(abs_cache, rel_cache, stem, ext)
   return pages
 end
 
+--- Copy a file in binary mode.
+--- @param src string Source file path
+--- @param dst string Destination file path
+--- @return boolean True on success
+local function copy_file(src, dst)
+  local f_in = io.open(src, 'rb')
+  if not f_in then
+    log.log_warning(EXTENSION_NAME, 'output-file: could not read source file: ' .. src)
+    return false
+  end
+  local data = f_in:read('*a')
+  f_in:close()
+  local f_out = io.open(dst, 'wb')
+  if not f_out then
+    log.log_warning(EXTENSION_NAME, 'output-file: could not write to destination: ' .. dst)
+    return false
+  end
+  f_out:write(data)
+  f_out:close()
+  return true
+end
+
+--- Resolve a path to absolute, accounting for document directory.
+--- Leading '/' paths are resolved relative to the project root.
+--- Other paths are resolved relative to the document directory.
+--- @param path string The path to resolve
+--- @return string Absolute path
+local function resolve_to_absolute(path)
+  -- Leading '/' means project root
+  if path:sub(1, 1) == '/' then
+    return paths.resolve_project_path(path)
+  end
+  -- Relative path: resolve against the document's directory
+  local input_file = quarto.doc.input_file
+  if input_file and input_file ~= '' then
+    local doc_dir = pandoc.path.directory(input_file)
+    if doc_dir and doc_dir ~= '' and doc_dir ~= '.' then
+      return pandoc.path.join({ quarto.project.directory, doc_dir, path })
+    end
+  end
+  -- Document is at project root
+  if quarto.project.directory then
+    return pandoc.path.join({ quarto.project.directory, path })
+  end
+  return path
+end
+
+--- Resolve the output path for saving compiled images.
+--- @param global_dir string|nil Global output-directory value
+--- @param block_dir string|nil Per-block output-directory value
+--- @param block_filename string|nil Per-block output-filename value
+--- @param label string|nil Block label (e.g., "fig-diagram")
+--- @param counter_name string Auto-generated name (e.g., "typst-block-3")
+--- @param img_format string Image format extension (e.g., "png")
+--- @return string|nil Resolved absolute path, or nil if no output path
+local function resolve_output_path(global_dir, block_dir, block_filename, label, counter_name, img_format)
+  -- Determine the filename
+  local filename = block_filename
+  if not filename or filename == '' then
+    -- Auto-generate from label or counter
+    local stem = (type(label) == 'string' and label ~= '') and label or counter_name
+    filename = stem .. '.' .. img_format
+  end
+
+  -- If filename starts with '/', it is a project-root path; ignore directory
+  if filename:sub(1, 1) == '/' then
+    return resolve_to_absolute(filename)
+  end
+
+  -- Determine the directory (per-block overrides global)
+  local dir = block_dir or global_dir
+  if not dir or dir == '' then
+    -- No directory and filename was explicitly set (not auto-generated)
+    if block_filename and block_filename ~= '' then
+      return resolve_to_absolute(filename)
+    end
+    return nil
+  end
+
+  -- Join directory and filename
+  local joined = dir
+  -- Ensure trailing separator for joining
+  if joined:sub(-1) ~= '/' then
+    joined = joined .. '/'
+  end
+  joined = joined .. filename
+
+  return resolve_to_absolute(joined)
+end
+
+--- Compute a document-relative path from an absolute path.
+--- Uses the same approach as ensure_cache_dir: paths are relative to the
+--- project root, then prepended with quarto.project.offset when the document
+--- lives in a subdirectory.
+--- @param abs_path string Absolute path
+--- @return string Document-relative path suitable for pandoc Image elements
+local function make_doc_relative(abs_path)
+  local rel = pandoc.path.make_relative(abs_path, quarto.project.directory)
+  if quarto.project.offset and quarto.project.offset ~= '' and quarto.project.offset ~= '.' then
+    rel = pandoc.path.join({ quarto.project.offset, rel })
+  end
+  return rel
+end
+
+--- Save compiled image files to the resolved output path.
+--- Copies from the cache to the output location and returns
+--- document-relative paths so the pandoc elements can reference them.
+--- @param page_paths table List of relative page paths from compilation
+--- @param output_path string Resolved absolute output path
+--- @param mode_suffix string|nil Optional suffix for dual-mode ("-light", "-dark")
+--- @param img_format string Image format (e.g., "png")
+--- @return table|nil List of document-relative destination paths, or nil on failure
+local function save_output_files(page_paths, output_path, mode_suffix, img_format)
+  if not page_paths or #page_paths == 0 or not output_path then
+    return nil
+  end
+
+  local dir = pandoc.path.directory(output_path)
+  local filename = pandoc.path.filename(output_path)
+  local stem, ext = filename:match('^(.+)%.([^.]+)$')
+  if not stem then
+    stem = filename
+    ext = img_format
+  end
+
+  if ext ~= img_format then
+    log.log_warning(
+      EXTENSION_NAME,
+      'output-filename extension ".' .. ext .. '" does not match output format "' .. img_format .. '".'
+    )
+  end
+
+  -- Create intermediate directories
+  if dir and dir ~= '' and dir ~= '.' then
+    local ok, err = pcall(pandoc.system.make_directory, dir, true)
+    if not ok then
+      log.log_warning(EXTENSION_NAME, 'output-directory: could not create directory: ' .. tostring(err))
+      return nil
+    end
+  end
+
+  mode_suffix = mode_suffix or ''
+  local result_paths = {}
+
+  -- page_paths are document-relative; resolve to absolute via the document directory
+  local doc_abs_dir = quarto.project.directory
+  local input_file = quarto.doc.input_file
+  if input_file and input_file ~= '' then
+    local doc_subdir = pandoc.path.directory(input_file)
+    if doc_subdir and doc_subdir ~= '' and doc_subdir ~= '.' then
+      doc_abs_dir = pandoc.path.join({ quarto.project.directory, doc_subdir })
+    end
+  end
+
+  if #page_paths == 1 then
+    local src = pandoc.path.normalize(pandoc.path.join({ doc_abs_dir, page_paths[1] }))
+    local dst = pandoc.path.join({ dir, stem .. mode_suffix .. '.' .. ext })
+    if copy_file(src, dst) then
+      log.log_debug(EXTENSION_NAME, 'Saved image to ' .. dst)
+      result_paths[1] = make_doc_relative(dst)
+    else
+      return nil
+    end
+  else
+    for i, page_path in ipairs(page_paths) do
+      local src = pandoc.path.normalize(pandoc.path.join({ doc_abs_dir, page_path }))
+      local dst = pandoc.path.join({ dir, stem .. mode_suffix .. tostring(i) .. '.' .. ext })
+      if copy_file(src, dst) then
+        log.log_debug(EXTENSION_NAME, 'Saved image to ' .. dst)
+        result_paths[#result_paths + 1] = make_doc_relative(dst)
+      else
+        return nil
+      end
+    end
+  end
+
+  return result_paths
+end
+
 --- Compile Typst source to an image file (or multiple files for multi-page output).
 --- Uses stdin to pass source code, avoiding temporary .typ files.
 --- @param source string Full Typst source code
@@ -849,13 +1032,14 @@ end
 --- @param opts table Resolved options (colours must be plain strings)
 --- @param img_format string Target image format
 --- @return pandoc.Block|nil Result block, or nil on failure
+--- @return table|nil List of selected page paths, or nil on failure
 --- @return string|nil Error message on compilation failure
 local function compile_to_result(code, opts, img_format)
   local full_source = build_typst_source(code, opts)
   local all_pages, compile_err = compile_typst(full_source, opts, img_format)
 
   if not all_pages then
-    return nil, compile_err
+    return nil, nil, compile_err
   end
 
   local selected_pages
@@ -874,10 +1058,10 @@ local function compile_to_result(code, opts, img_format)
   end
 
   if #selected_pages == 0 then
-    return nil, nil
+    return nil, nil, nil
   end
 
-  return wrap_alignment(create_multi_page_element(selected_pages, opts), opts), nil
+  return wrap_alignment(create_multi_page_element(selected_pages, opts), opts), selected_pages, nil
 end
 
 --- Read an external `.typ` file, resolving relative to the project directory.
@@ -947,6 +1131,7 @@ local function get_configuration(meta)
       'format', 'dpi', 'width', 'height', 'margin',
       'cache', 'echo', 'eval', 'include', 'output', 'output-location', 'classes',
       'root', 'package-path', 'pages', 'layout-ncol', 'align',
+      'output-directory',
     }
     for _, k in ipairs(config_keys) do
       local default_val = DEFAULTS[k]
@@ -1226,8 +1411,8 @@ local function process_codeblock(el)
   if dual_mode then
     local light_opts = resolve_opts_colours(opts, 'light')
     local dark_opts = resolve_opts_colours(opts, 'dark')
-    local light_content, light_err = compile_to_result(code, light_opts, img_format)
-    local dark_content, dark_err = compile_to_result(code, dark_opts, img_format)
+    local light_content, light_pages, light_err = compile_to_result(code, light_opts, img_format)
+    local dark_content, dark_pages, dark_err = compile_to_result(code, dark_opts, img_format)
 
     if not light_content and not dark_content then
       log.log_warning(EXTENSION_NAME, 'Compilation failed; returning error block.')
@@ -1237,6 +1422,29 @@ local function process_codeblock(el)
         return pandoc.Blocks({ echo_block, error_block })
       end
       return error_block
+    end
+
+    -- Resolve output path after compilation so block_counter is current
+    local output_path = resolve_output_path(
+      global_config['output-directory'], opts['output-directory'],
+      opts['output-filename'], opts.label,
+      'typst-block-' .. block_counter, img_format
+    )
+
+    -- Save to output directory and rebuild elements using output paths
+    if output_path then
+      if light_pages then
+        local out_pages = save_output_files(light_pages, output_path, '-light', img_format)
+        if out_pages then
+          light_content = wrap_alignment(create_multi_page_element(out_pages, light_opts), light_opts)
+        end
+      end
+      if dark_pages then
+        local out_pages = save_output_files(dark_pages, output_path, '-dark', img_format)
+        if out_pages then
+          dark_content = wrap_alignment(create_multi_page_element(out_pages, dark_opts), dark_opts)
+        end
+      end
     end
 
     local blocks = {}
@@ -1258,7 +1466,7 @@ local function process_codeblock(el)
     local resolved_opts = has_dual_mode_colours(opts)
         and resolve_opts_colours(opts, global_brand_mode)
         or opts
-    local content, compile_err = compile_to_result(code, resolved_opts, img_format)
+    local content, selected_pages, compile_err = compile_to_result(code, resolved_opts, img_format)
 
     if not content then
       if compile_err then
@@ -1272,6 +1480,21 @@ local function process_codeblock(el)
       end
       log.log_warning(EXTENSION_NAME, 'No pages matched the selection; returning empty block.')
       return pandoc.Null()
+    end
+
+    -- Resolve output path after compilation so block_counter is current
+    local output_path = resolve_output_path(
+      global_config['output-directory'], opts['output-directory'],
+      opts['output-filename'], opts.label,
+      'typst-block-' .. block_counter, img_format
+    )
+
+    -- Save to output directory and rebuild element using output paths
+    if output_path and selected_pages then
+      local out_pages = save_output_files(selected_pages, output_path, nil, img_format)
+      if out_pages then
+        content = wrap_alignment(create_multi_page_element(out_pages, resolved_opts), resolved_opts)
+      end
     end
 
     result = cell.wrap_crossref(content, opts, REF_TYPE_NAMES)

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -600,6 +600,10 @@ local function copy_file(src, dst)
   end
   local data = f_in:read('*a')
   f_in:close()
+  if not data then
+    log.log_warning(EXTENSION_NAME, 'output-file: failed to read data from ' .. src)
+    return false
+  end
   local f_out = io.open(dst, 'wb')
   if not f_out then
     log.log_warning(EXTENSION_NAME, 'output-file: could not write to destination: ' .. dst)
@@ -668,12 +672,7 @@ local function resolve_output_path(global_dir, block_dir, block_filename, label,
   end
 
   -- Join directory and filename
-  local joined = dir
-  -- Ensure trailing separator for joining
-  if joined:sub(-1) ~= '/' then
-    joined = joined .. '/'
-  end
-  joined = joined .. filename
+  local joined = pandoc.path.join({ dir, filename })
 
   return resolve_to_absolute(joined)
 end
@@ -1407,6 +1406,11 @@ local function process_codeblock(el)
   -- Dual-mode rendering for HTML/Reveal.js when both light and dark colours are present
   local dual_mode = quarto.format.is_html_output() and has_dual_mode_colours(opts)
 
+  -- Capture the next block counter value before compilations increment it.
+  -- In dual-mode, compile_to_result is called twice, each incrementing block_counter,
+  -- but we want the first value for the auto-generated output filename.
+  local next_block_counter = block_counter + 1
+
   local result
   if dual_mode then
     local light_opts = resolve_opts_colours(opts, 'light')
@@ -1424,11 +1428,10 @@ local function process_codeblock(el)
       return error_block
     end
 
-    -- Resolve output path after compilation so block_counter is current
     local output_path = resolve_output_path(
       global_config['output-directory'], opts['output-directory'],
       opts['output-filename'], opts.label,
-      'typst-block-' .. block_counter, img_format
+      'typst-block-' .. next_block_counter, img_format
     )
 
     -- Save to output directory and rebuild elements using output paths
@@ -1482,11 +1485,10 @@ local function process_codeblock(el)
       return pandoc.Null()
     end
 
-    -- Resolve output path after compilation so block_counter is current
     local output_path = resolve_output_path(
       global_config['output-directory'], opts['output-directory'],
       opts['output-filename'], opts.label,
-      'typst-block-' .. block_counter, img_format
+      'typst-block-' .. next_block_counter, img_format
     )
 
     -- Save to output directory and rebuild element using output paths

--- a/example.qmd
+++ b/example.qmd
@@ -418,6 +418,43 @@ Render an external `.typ` file instead of inline code:
 //| file: _example.typ
 ```
 
+## Output Directory
+
+By default, compiled images are only stored in the internal cache directory (`.quarto/typst-render/`) with auto-generated filenames.
+Set `output-directory` to also save copies to a predictable location.
+Use `output-filename` to override the auto-generated filename.
+
+Paths follow Quarto conventions: a leading `/` is relative to the project root, otherwise relative to the document directory.
+
+When `output-directory` is set and no `output-filename` is given, the filename is auto-generated from the block label (e.g., `fig-diagram.png`) or block counter (e.g., `typst-block-1.png`).
+
+### Save with Explicit Filename
+
+```{typst}
+//| echo: fenced
+//| output-directory: _output
+//| output-filename: hello-typst.png
+//| format: png
+#set text(size: 14pt)
+#align(center)[Hello from *Typst*, saved to `_output/hello-typst.png`.]
+```
+
+### Auto-Generated Filename from Label
+
+When a label is present, the filename is derived from the label:
+
+```{typst}
+//| echo: fenced
+//| label: fig-auto-saved
+//| cap: "A block saved with an auto-generated filename."
+//| output-directory: _output
+//| format: png
+#set text(size: 14pt)
+#align(center)[
+  #circle(radius: 0.8cm, fill: eastern.lighten(60%))
+]
+```
+
 ::: {.content-hidden when-format="revealjs" when-format="pptx"}
 
 ## Preamble
@@ -581,6 +618,8 @@ extensions:
 | `cache`           | boolean\|string | `true`    | Cache compiled images. Use `"clean"` to also remove stale cache files.            |
 | `input`           | object          | (none)    | Key-value pairs passed as `--input` flags to Typst CLI.                           |
 | `file`            | string          | (none)    | Path to external `.typ` file to render.                                           |
+| `output-directory` | string         | (none)    | Directory for saving compiled images.                                             |
+| `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`.            |
 | `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).              |
 | `eval`            | boolean         | `true`    | Compile Typst code to image.                                                      |
 | `include`         | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                        |


### PR DESCRIPTION
Add `output-directory` and `output-filename` options that copy compiled Typst images to user-specified locations.
Paths follow Quarto conventions: a leading `/` is relative to the project root, otherwise relative to the document directory.

When `output-directory` is set, the rendered document references the saved images directly instead of the internal cache.
Auto-generated filenames are derived from the block label (e.g., `fig-diagram.png`) or block counter (e.g., `typst-block-1.png`).
Multi-page output appends page numbers before the extension.
Dual-mode (light/dark) rendering appends `-light`/`-dark` suffixes.

`output-directory` is available both globally and per block.
`output-filename` is per block only; a leading `/` overrides the global directory entirely.