### PR TITLE
fix: prevent double-wrapping of resolved brand colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: prevent double-wrapping of resolved brand colours when `background: auto` or `foreground: auto` is set globally with a `_brand.yml`.
+
 ## 0.10.0 (2026-04-15)
 
 ### New Features

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1283,14 +1283,14 @@ local function process_codeblock(el)
   local opts = cell.merge_options(block_opts, global_config, DEFAULTS)
   opts._block_input = block_input_str
 
-  -- Resolve per-block colour values (convert "auto" via brand, hex via css_colour_to_typst)
+  -- Resolve per-block colour overrides only. Values inherited from global_config
+  -- are already resolved (e.g. 'rgb("#FAF6EE")') and must not be re-wrapped.
   for _, colour_key in ipairs({ 'background', 'foreground' }) do
-    local val = opts[colour_key]
-    if val == 'auto' then
-      local resolved = resolve_colour_config('auto', colour_key)
-      opts[colour_key] = resolved or DEFAULTS[colour_key]
-    elseif type(val) == 'string' and val ~= DEFAULTS[colour_key] then
-      opts[colour_key] = css_colour_to_typst(val)
+    local block_val = block_opts[colour_key]
+    if block_val == 'auto' then
+      opts[colour_key] = resolve_colour_config('auto', colour_key) or DEFAULTS[colour_key]
+    elseif type(block_val) == 'string' and block_val ~= DEFAULTS[colour_key] then
+      opts[colour_key] = css_colour_to_typst(block_val)
     end
   end
 


### PR DESCRIPTION
Setting `background: auto` or `foreground: auto` globally with a `_brand.yml` produced invalid Typst like `rgb("rgb("#FAF6EE")")` and aborted compilation on every block. The resolved colour from `global_config` was passed back through `css_colour_to_typst` in the per-block loop, which matched the `rgb(` prefix and wrapped it a second time.

The per-block colour loop now reads overrides from `block_opts` (pre-merge) instead of the merged `opts`, so inherited global values are left untouched while block-level `auto`, hex, and CSS values are still resolved and wrapped once.

Verified end-to-end with a `_brand.yml` defining `background: #FAF6EE`: global `auto`, per-block hex overrides, per-block `auto` overrides, and per-block `none` all render with the correct single-wrapped fill.