### PR TITLE
feat: size SVG output in CSS pixels at configured dpi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- feat: SVG output in HTML is now sized in CSS pixels at the configured `dpi` instead of physical units.
+  After Typst writes each SVG, the root `<svg>` element's `width`/`height` (emitted by Typst in `pt`) are rewritten to `px` at `dpi` pixels per inch.
+  `viewBox` is left untouched, so aspect ratio is preserved.
+  This makes SVG and PNG output display at the same on-screen size for the same Typst page and `dpi`.
+  Existing SVG users will see images grow at the default `dpi: 144`: a `10cm` wide page previously rendered at ~378 CSS px and now renders at ~567 CSS px.
+  Lower `dpi` to shrink; raise it to enlarge.
+  Cached SVG files from prior versions keep the old sizing; set `cache-refresh: true` or clear the cache to rerender them.
+
 ## 0.12.0 (2026-04-22)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   This makes SVG and PNG output display at the same on-screen size for the same Typst page and `dpi`.
   Existing SVG users will see images grow at the default `dpi: 144`: a `10cm` wide page previously rendered at ~378 CSS px and now renders at ~567 CSS px.
   Lower `dpi` to shrink; raise it to enlarge.
-  Cached SVG files from prior versions keep the old sizing; set `cache-refresh: true` or clear the cache to rerender them.
+  The SVG cache key now separates HTML from non-HTML consumers, so cache entries from prior versions are bypassed automatically; set `cache-refresh: true` to sweep the stale files.
 
 ## 0.12.0 (2026-04-22)
 

--- a/README.md
+++ b/README.md
@@ -311,31 +311,31 @@ Per-block input override using comma-separated syntax:
 
 ### Options
 
-| Option            | Type            | Default   | Description                                                                                   |
-| ----------------- | --------------- | --------- | --------------------------------------------------------------------------------------------- |
-| `format`          | string          | (auto)    | Image format: `png`, `svg`, `pdf`.                                                            |
-| `dpi`             | number          | `144`     | Pixels per inch (PNG only).                                                                   |
-| `width`           | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                               |
-| `height`          | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                              |
-| `margin`          | string          | `"0.5em"` | Page margin for image compilation; block `inset` with `output: asis`.                         |
-| `background`      | string\|object  | `"none"`  | Page fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map. |
-| `foreground`      | string\|object  | (none)    | Text fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map. |
-| `preamble`        | string          | `""`      | Typst code or path to a `.typ` file prepended before user code.                               |
-| `cache`           | boolean         | `true`    | Cache compiled images. Set `false` to skip cache (existing files are preserved).              |
-| `cache-refresh`   | boolean         | `false`   | Remove stale cache files after each render (global only).                                     |
-| `input`           | object          | (none)    | Key-value pairs passed as `--input` flags to Typst CLI.                                       |
-| `file`            | string          | (none)    | Path to external `.typ` file to render.                                                       |
-| `output-directory` | string         | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).               |
-| `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted. |
-| `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).                          |
-| `eval`            | boolean         | `true`    | Compile Typst code to image.                                                                  |
-| `include`         | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                                    |
-| `output`          | boolean\|string | `true`    | Show rendered output. Use `asis` for native Typst passthrough.                                |
-| `output-location` | string          | (none)    | Output placement in Reveal.js (`fragment`, `slide`, `column`, `column-fragment`).             |
-| `classes`         | string          | (none)    | Space-separated CSS classes on the output image (e.g., `r-stretch`).                          |
-| `pages`           | string          | `"all"`   | Pages to include from multi-page output: `all`, `1`, `1-3`, `2,5`, `3-`.                      |
-| `layout-ncol`     | string          | (none)    | Number of columns for arranging multi-page output. Omit for vertical stack.                   |
-| `align`           | string          | (none)    | Horizontal alignment: `left`, `center`, `right`, `default`.                                   |
+| Option             | Type            | Default   | Description                                                                                        |
+| ------------------ | --------------- | --------- | -------------------------------------------------------------------------------------------------- |
+| `format`           | string          | (auto)    | Image format: `png`, `svg`, `pdf`.                                                                 |
+| `dpi`              | number          | `144`     | Pixels per inch. PNG rasterisation density and CSS pixel size of SVG output in HTML.               |
+| `width`            | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                                    |
+| `height`           | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                                   |
+| `margin`           | string          | `"0.5em"` | Page margin for image compilation; block `inset` with `output: asis`.                              |
+| `background`       | string\|object  | `"none"`  | Page fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map.      |
+| `foreground`       | string\|object  | (none)    | Text fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map.      |
+| `preamble`         | string          | `""`      | Typst code or path to a `.typ` file prepended before user code.                                    |
+| `cache`            | boolean         | `true`    | Cache compiled images. Set `false` to skip cache (existing files are preserved).                   |
+| `cache-refresh`    | boolean         | `false`   | Remove stale cache files after each render (global only).                                          |
+| `input`            | object          | (none)    | Key-value pairs passed as `--input` flags to Typst CLI.                                            |
+| `file`             | string          | (none)    | Path to external `.typ` file to render.                                                            |
+| `output-directory` | string          | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).                   |
+| `output-filename`  | string          | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted. |
+| `echo`             | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).                               |
+| `eval`             | boolean         | `true`    | Compile Typst code to image.                                                                       |
+| `include`          | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                                         |
+| `output`           | boolean\|string | `true`    | Show rendered output. Use `asis` for native Typst passthrough.                                     |
+| `output-location`  | string          | (none)    | Output placement in Reveal.js (`fragment`, `slide`, `column`, `column-fragment`).                  |
+| `classes`          | string          | (none)    | Space-separated CSS classes on the output image (e.g., `r-stretch`).                               |
+| `pages`            | string          | `"all"`   | Pages to include from multi-page output: `all`, `1`, `1-3`, `2,5`, `3-`.                           |
+| `layout-ncol`      | string          | (none)    | Number of columns for arranging multi-page output. Omit for vertical stack.                        |
+| `align`            | string          | (none)    | Horizontal alignment: `left`, `center`, `right`, `default`.                                        |
 
 Any unknown option with a string value is forwarded as an HTML attribute on the output image element (e.g., `//| style: "max-height: 300px;"`).
 Values that look like booleans (`true`/`false`) must be quoted to be forwarded (e.g., `//| data-lazy: "true"`).
@@ -369,6 +369,10 @@ These options can only be set in the document YAML and cannot be overridden per 
 | Typst           | `png`                |
 | DOCX / PPTX     | `png`                |
 | Other           | `png`                |
+
+For HTML output, SVG images are rewritten so that the root `<svg>` element's `width`/`height` (emitted by Typst in `pt`) are converted to `px` at the configured `dpi`.
+This keeps SVG and PNG output at the same on-screen size for the same Typst page and `dpi`.
+`viewBox` is not modified, so aspect ratio is preserved.
 
 ### Echo/Eval Behaviour
 

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -12,7 +12,7 @@ options:
   dpi:
     type: number
     default: 144
-    description: "Pixels per inch for PNG output."
+    description: "Pixels per inch. Controls PNG rasterisation density and the CSS pixel size of SVG output (the root <svg> width/height emitted by Typst in pt are rewritten to px at this dpi so SVG and PNG display at the same size in HTML)."
   width:
     type: string
     default: "auto"
@@ -137,7 +137,7 @@ attributes:
       description: "Image output format for this block."
     dpi:
       type: number
-      description: "Pixels per inch for PNG output."
+      description: "Pixels per inch. Controls PNG rasterisation density and the CSS pixel size of SVG output in HTML."
     width:
       type: string
       description: "Page width for image compilation (ignored with output: asis)."

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -680,8 +680,9 @@ end
 --- @param rel_cache string Relative path to cache directory
 --- @param stem string File stem (without extension)
 --- @param ext string File extension (e.g., "png", "svg")
+--- @param on_page function|nil Optional callback invoked as on_page(abs_page_path) for each discovered file, before it is recorded
 --- @return table List of relative paths to discovered page files
-local function discover_page_files(abs_cache, rel_cache, stem, ext)
+local function discover_page_files(abs_cache, rel_cache, stem, ext, on_page)
   local pages = {}
   local i = 1
   while true do
@@ -692,11 +693,79 @@ local function discover_page_files(abs_cache, rel_cache, stem, ext)
       break
     end
     f:close()
+    if on_page then
+      on_page(page_path)
+    end
     used_cache_files[page_name] = true
     pages[#pages + 1] = pandoc.path.join({ rel_cache, page_name })
     i = i + 1
   end
   return pages
+end
+
+local function format_svg_px(value)
+  if value == math.floor(value) then
+    return string.format('%d', value)
+  end
+  return string.format('%.2f', value)
+end
+
+--- Patterns for Typst-emitted root `<svg>` width/height in pt. Each capture
+--- is: (1) attribute name and `=`, (2) opening quote (kept consistent via `%2`
+--- back-reference on the closing quote), (3) the numeric value.
+local SVG_ROOT_PT_PATTERNS = {
+  '(%swidth=)(["\'])(%-?%d*%.?%d+)pt%2',
+  '(%sheight=)(["\'])(%-?%d*%.?%d+)pt%2',
+}
+
+--- Rewrite `width`/`height` on a root <svg> tag from pt to px at the given
+--- dpi. Typst's SVG writer always emits pt on the root (even when the Typst
+--- page is auto-sized); browsers treat <svg width="Npt"> as physical points
+--- (1/72 in), which renders smaller than a PNG rasterised at the same dpi.
+--- Converting to px at our dpi makes SVG and PNG display at the same size.
+--- `viewBox` is untouched so aspect ratio and inner coordinates are preserved.
+--- @param svg_tag string Opening `<svg ... >` tag, including angle brackets
+--- @param dpi number Target resolution in pixels per inch
+--- @return string Rewritten tag (unchanged if no pt values found)
+local function rewrite_svg_root_tag(svg_tag, dpi)
+  local scale = dpi / 72
+  for _, pattern in ipairs(SVG_ROOT_PT_PATTERNS) do
+    svg_tag = svg_tag:gsub(pattern, function(prefix, quote, num)
+      return prefix .. quote .. format_svg_px(tonumber(num) * scale) .. 'px' .. quote
+    end)
+  end
+  return svg_tag
+end
+
+--- Rewrite a single Typst-produced SVG file in place so the root <svg>
+--- width/height are expressed in px at the given dpi. No-op if the tag is
+--- missing or already contains no pt values.
+--- @param path string Absolute path to the SVG file
+--- @param dpi number Target resolution in pixels per inch
+local function rewrite_svg_file_size(path, dpi)
+  local f_in = io.open(path, 'rb')
+  if not f_in then
+    return
+  end
+  local data = f_in:read('*a')
+  f_in:close()
+  local start_pos, end_pos = data:find('<svg[^>]*>')
+  if not start_pos then
+    return
+  end
+  local old_tag = data:sub(start_pos, end_pos)
+  local new_tag = rewrite_svg_root_tag(old_tag, dpi)
+  if new_tag == old_tag then
+    return
+  end
+  local new_data = data:sub(1, start_pos - 1) .. new_tag .. data:sub(end_pos + 1)
+  local f_out = io.open(path, 'wb')
+  if not f_out then
+    log.log_warning(EXTENSION_NAME, 'Failed to rewrite SVG size: could not open for write: ' .. path)
+    return
+  end
+  f_out:write(new_data)
+  f_out:close()
 end
 
 --- Copy a file in binary mode.
@@ -1019,7 +1088,18 @@ local function compile_typst(source, opts, img_format)
 
   if is_paged then
     -- PNG/SVG: Typst CLI generates {stem}1.{ext}, {stem}2.{ext}, ...
-    local pages = discover_page_files(abs_cache, rel_cache, stem, img_format)
+    -- SVG pages get a per-file rewrite so root <svg> width/height are in px
+    -- rather than pt; keeps SVG and PNG at the same on-screen size for the
+    -- same Typst page + dpi. (Cached files are already rewritten: dpi is
+    -- part of the cache key.)
+    local on_page = nil
+    if img_format == 'svg' then
+      local dpi_num = tonumber(dpi)
+      on_page = function(path)
+        rewrite_svg_file_size(path, dpi_num)
+      end
+    end
+    local pages = discover_page_files(abs_cache, rel_cache, stem, img_format, on_page)
     if #pages > 0 then
       return pages
     end

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1007,6 +1007,13 @@ local function compile_typst(source, opts, img_format)
   if import_content ~= '' then
     hash_source = hash_source .. '|imports:' .. import_content
   end
+  -- SVG output is post-processed (pt -> px at dpi) only for HTML output, and the
+  -- rewrite mutates the cached file in place. Without this, a non-HTML render
+  -- producing an SVG at the same stem would populate the cache with pt units,
+  -- and the next HTML render would hit that cache and serve pt-sized SVG.
+  if img_format == 'svg' then
+    hash_source = hash_source .. '|html:' .. (quarto.format.is_html_output() and '1' or '0')
+  end
 
   local use_cache = opts.cache ~= false
   local stem = compute_cache_stem(hash_source, img_format, dpi, opts.label, opts._inline)
@@ -1111,8 +1118,9 @@ local function compile_typst(source, opts, img_format)
     -- For HTML output, SVG pages get a per-file rewrite so root <svg>
     -- width/height are in px rather than pt; keeps SVG and PNG at the same
     -- on-screen size for the same Typst page + dpi. Other formats keep the
-    -- pt units Typst produced, which are correct for print. Cached files
-    -- are already rewritten (dpi is part of the cache key).
+    -- pt units Typst produced, which are correct for print. HTML-vs-not is
+    -- part of the SVG cache key, so cached entries are never served to the
+    -- wrong consumer.
     local on_page = nil
     if img_format == 'svg' and quarto.format.is_html_output() then
       local dpi_num = tonumber(dpi)

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -739,7 +739,9 @@ end
 
 --- Rewrite a single Typst-produced SVG file in place so the root <svg>
 --- width/height are expressed in px at the given dpi. No-op if the tag is
---- missing or already contains no pt values.
+--- missing or already contains no pt values. Writes atomically via a
+--- temp file + rename so a mid-write failure (e.g. disk full) cannot
+--- poison the cache with a truncated SVG.
 --- @param path string Absolute path to the SVG file
 --- @param dpi number Target resolution in pixels per inch
 local function rewrite_svg_file_size(path, dpi)
@@ -759,13 +761,24 @@ local function rewrite_svg_file_size(path, dpi)
     return
   end
   local new_data = data:sub(1, start_pos - 1) .. new_tag .. data:sub(end_pos + 1)
-  local f_out = io.open(path, 'wb')
+  local tmp_path = path .. '.tmp'
+  local f_out, open_err = io.open(tmp_path, 'wb')
   if not f_out then
-    log.log_warning(EXTENSION_NAME, 'Failed to rewrite SVG size: could not open for write: ' .. path)
+    log.log_warning(EXTENSION_NAME, 'Failed to rewrite SVG size: cannot open ' .. tmp_path .. ': ' .. (open_err or 'unknown'))
     return
   end
-  f_out:write(new_data)
-  f_out:close()
+  local write_ok, write_err = f_out:write(new_data)
+  local close_ok, close_err = f_out:close()
+  if not write_ok or not close_ok then
+    log.log_warning(EXTENSION_NAME, 'Failed to rewrite SVG size: write/close failed on ' .. tmp_path .. ': ' .. (write_err or close_err or 'unknown'))
+    os.remove(tmp_path)
+    return
+  end
+  local rename_ok, rename_err = os.rename(tmp_path, path)
+  if not rename_ok then
+    log.log_warning(EXTENSION_NAME, 'Failed to rewrite SVG size: rename failed for ' .. path .. ': ' .. (rename_err or 'unknown'))
+    os.remove(tmp_path)
+  end
 end
 
 --- Copy a file in binary mode.
@@ -1088,12 +1101,13 @@ local function compile_typst(source, opts, img_format)
 
   if is_paged then
     -- PNG/SVG: Typst CLI generates {stem}1.{ext}, {stem}2.{ext}, ...
-    -- SVG pages get a per-file rewrite so root <svg> width/height are in px
-    -- rather than pt; keeps SVG and PNG at the same on-screen size for the
-    -- same Typst page + dpi. (Cached files are already rewritten: dpi is
-    -- part of the cache key.)
+    -- For HTML output, SVG pages get a per-file rewrite so root <svg>
+    -- width/height are in px rather than pt; keeps SVG and PNG at the same
+    -- on-screen size for the same Typst page + dpi. Other formats keep the
+    -- pt units Typst produced, which are correct for print. Cached files
+    -- are already rewritten (dpi is part of the cache key).
     local on_page = nil
-    if img_format == 'svg' then
+    if img_format == 'svg' and quarto.format.is_html_output() then
       local dpi_num = tonumber(dpi)
       on_page = function(path)
         rewrite_svg_file_size(path, dpi_num)

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -774,7 +774,14 @@ local function rewrite_svg_file_size(path, dpi)
     os.remove(tmp_path)
     return
   end
+  -- Windows `os.rename` fails if the destination exists; POSIX atomically
+  -- replaces. Try a direct rename first, then retry after removing on
+  -- failure so behaviour is portable (briefly non-atomic on Windows only).
   local rename_ok, rename_err = os.rename(tmp_path, path)
+  if not rename_ok then
+    os.remove(path)
+    rename_ok, rename_err = os.rename(tmp_path, path)
+  end
   if not rename_ok then
     log.log_warning(EXTENSION_NAME, 'Failed to rewrite SVG size: rename failed for ' .. path .. ': ' .. (rename_err or 'unknown'))
     os.remove(tmp_path)
@@ -1865,7 +1872,8 @@ local function cleanup_cache(doc) -- luacheck: ignore 212
   for _, filename in ipairs(entries) do
     if filename:match('^typst%-') and not used_cache_files[filename] then
       local ext = filename:match('%.(%w+)$')
-      if ext and used_cache_formats[ext] then
+      -- Also sweep orphan `.tmp` files left by an interrupted SVG rewrite.
+      if ext and (used_cache_formats[ext] or ext == 'tmp') then
         local filepath = pandoc.path.join({ abs_cache, filename })
         local rm_ok, rm_err = os.remove(filepath)
         if rm_ok then

--- a/example.qmd
+++ b/example.qmd
@@ -608,7 +608,7 @@ extensions:
 | Option            | Type            | Default   | Description                                                                       |
 | ----------------- | --------------- | --------- | --------------------------------------------------------------------------------- |
 | `format`          | string          | (auto)    | Image format: `png`, `svg`, `pdf`.                                                |
-| `dpi`             | number          | `144`     | Pixels per inch (PNG only).                                                       |
+| `dpi`             | number          | `144`     | Pixels per inch. PNG rasterisation density and CSS pixel size of SVG output in HTML. |
 | `width`           | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                   |
 | `height`          | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                  |
 | `margin`          | string          | `"0.5em"` | Page margin for image compilation; block `inset` with `output: asis`.             |


### PR DESCRIPTION
SVG output in HTML is now sized in CSS pixels at the configured `dpi` rather than physical points.
After Typst writes each SVG, the root `<svg>` element's `width` and `height` (which Typst always emits in `pt`) are rewritten to `px` at `dpi` pixels per inch; `viewBox` is left untouched so aspect ratio is preserved.
With the default `dpi: 144`, a `10cm` wide page that previously rendered at ~378 CSS pixels now renders at ~567 CSS pixels, matching the size of a PNG rasterised at the same dpi.

The rewrite is gated on `quarto.format.is_html_output()` so other output formats continue to receive the original pt units, which are correct for print.
SVG files are patched in place with a temp file plus rename, with a portable fallback for Windows' non-replacing `os.rename`.
Orphan `.tmp` files left by an interrupted rewrite are swept by `cache-refresh: true` alongside other stale cache entries.

The SVG cache key is further salted with the HTML-vs-non-HTML consumer so a non-HTML render populating the cache with pt units cannot later be served to a browser.
This also bypasses SVG cache entries from prior versions automatically; those stale files can be cleared with `cache-refresh: true`.