### PR TITLE
fix: normalise echoed code block class without braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: strip the surrounding braces from the echoed code block class so `echo: true` produces a `typst` class (instead of `{typst}`) and `echo: fenced` produces a `` ```{typst} `` wrapper (instead of `` ```{{typst}} ``), restoring syntax highlighting on the echoed source.
+
 ## 0.12.0 (2026-04-22)
 
 ### New Features

--- a/_extensions/typst-render/_modules/code-cell.lua
+++ b/_extensions/typst-render/_modules/code-cell.lua
@@ -143,8 +143,9 @@ function M.new(config)
       '^%s*' .. escaped_prefix .. '%s*include:%s*',
       '^%s*' .. escaped_prefix .. '%s*output:%s*',
     }
+    local class_name = language:match('^{(.-)}$') or language
     if fenced then
-      local lines = { '```{' .. language .. '}' }
+      local lines = { '```{' .. class_name .. '}' }
       if option_lines then
         for _, line in ipairs(option_lines) do
           local is_meta = false
@@ -163,7 +164,7 @@ function M.new(config)
       lines[#lines + 1] = '```'
       return pandoc.CodeBlock(table.concat(lines, '\n'), pandoc.Attr('', { 'markdown' }, {}))
     end
-    return pandoc.CodeBlock(code, pandoc.Attr('', { language }, {}))
+    return pandoc.CodeBlock(code, pandoc.Attr('', { class_name }, {}))
   end
 
   --- Resolve and validate the output-location option.


### PR DESCRIPTION
The code-cell module was given `language='{typst}'` (the Quarto markdown engine literal), so `echo: true` emitted a CodeBlock whose class was `{typst}`, which is not a valid syntax-highlighting identifier and left the echoed source unhighlighted. The same root cause produced a double-braced ````{{typst}}```` wrapper for `echo: fenced`. Strip the outer braces from the language identifier when building the echo block so the class is `typst` and the fenced wrapper is ````{typst}````.