### PR TITLE
feat: add typst_define() helpers for R and Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: add `typst_define()` helpers (R and Python) that push named values from a knitr or jupyter session into every `{typst}` cell of the document. Defined values are exposed as a single dict named `typst_define` accessible as `#typst_define.<name>`. Supports scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames (column-wise), and numpy arrays. Helpers ship under `_extensions/typst-render/_resources/`.
+
 ## 0.12.2 (2026-05-11)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 - feat: add `typst_define()` helpers (R and Python) that push named values from a knitr or jupyter session into every `{typst}` cell of the document. Defined values are exposed as a single dict named `typst_define` accessible as `#typst_define.<name>`. Supports scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames (column-wise), and numpy arrays. Helpers ship under `_extensions/typst-render/_resources/`.
+- feat: the R helper registers a passthrough knitr engine for `typst` on source so `` ```{typst} `` chunks in knitr documents no longer emit "Unknown language engine" warnings and pass through cleanly to the typst-render filter.
 
 ## 0.12.2 (2026-05-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- feat: add `typst_define()` helpers (R and Python) that push named values from a knitr or jupyter session into every `{typst}` cell of the document. Defined values are exposed as a single dict named `typst_define` accessible as `#typst_define.<name>`. Supports scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames (column-wise), and numpy arrays. Helpers ship under `_extensions/typst-render/_resources/`.
+- feat: add `typst_define()` helpers (R and Python) that push named values from a knitr or jupyter session into every `{typst}` cell of the document. Defined values are exposed as a single dict named `typst_define` accessible as `#typst_define.<name>`. Supports scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames (column-wise), and numpy arrays. Helpers ship under `_extensions/typst-render/_resources/`. The data chunk that calls `typst_define()` must use the chunk option `output: asis` so the emitted metadata block is not wrapped in a cell-output `<div>`.
 - feat: the R helper registers a passthrough knitr engine for `typst` on source so `` ```{typst} `` chunks in knitr documents no longer emit "Unknown language engine" warnings and pass through cleanly to the typst-render filter.
 
 ## 0.12.2 (2026-05-11)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,52 @@ Select specific pages with `pages`:
 R, Python, or Julia cells with `output: asis` can output ` ```{typst} ` blocks.
 The filter processes these after engine execution.
 
+### Passing Data from R/Python
+
+Use `typst_define()` to push named values from a knitr or jupyter session into every `{typst}` cell of the document.
+Defined values are exposed as a single dict named `typst_define`; access them as `#typst_define.<name>`.
+Supported value types: scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames (column-wise), and numpy arrays.
+
+The helpers ship with the extension under `_extensions/typst-render/_resources/`.
+Either `source()`/`import` them, or copy-paste the body into a setup chunk.
+
+R example (in a knitr chunk):
+
+````markdown
+```{r}
+#| echo: false
+source("_extensions/typst-render/_resources/typst_define.R")
+typst_define(mtcars = head(mtcars), n = 42L)
+```
+
+```{typst}
+First mpg: #typst_define.mtcars.mpg.at(0), n = #typst_define.n
+```
+````
+
+Python example (in a jupyter chunk):
+
+```python
+import sys
+sys.path.insert(0, "_extensions/typst-render/_resources")
+from typst_define import typst_define
+import pandas as pd
+typst_define(df = pd.DataFrame({"x": [1, 2, 3]}), label = "hello")
+```
+
+```typst
+#typst_define.df.x.at(0), #typst_define.label
+```
+
+Caveats:
+
+- Define-before-use ordering: a `{typst}` cell that runs *before* any `typst_define()` call has no `typst_define` binding and will fail to compile if it references the name.
+- Identifier-named keys for dot access (`typst_define.x`).
+  Use `typst_define.at("f(x)")` for keys that are not valid Typst identifiers.
+- Quarto `freeze: true` interaction: changing data in a frozen chunk does not invalidate the freeze cache.
+  Re-render with `--no-cache` or remove `_freeze/` after edits.
+- Cache invalidation: any change to defined data invalidates every `{typst}` cell's render cache, even cells that do not reference the changed name.
+
 ## Configuration
 
 Configure the filter globally in your document YAML.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ source("_extensions/typst-render/_resources/typst_define.R")
 ```
 
 ```{r}
-#| echo: false
+#| output: asis
 typst_define(mtcars = head(mtcars)[, c("mpg", "cyl", "hp")], n = 42L)
 ```
 
@@ -217,7 +217,7 @@ from typst_define import typst_define
 ```
 
 ```{python}
-#| echo: false
+#| output: asis
 import pandas as pd
 typst_define(df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), label = "hello")
 ```

--- a/README.md
+++ b/README.md
@@ -182,29 +182,60 @@ R example (in a knitr chunk):
 
 ````markdown
 ```{r}
-#| echo: false
+#| include: false
 source("_extensions/typst-render/_resources/typst_define.R")
-typst_define(mtcars = head(mtcars), n = 42L)
+```
+
+```{r}
+#| echo: false
+typst_define(mtcars = head(mtcars)[, c("mpg", "cyl", "hp")], n = 42L)
 ```
 
 ```{typst}
-First mpg: #typst_define.mtcars.mpg.at(0), n = #typst_define.n
+n = #typst_define.n
+
+#let df = typst_define.mtcars
+#let cols = df.keys()
+#table(
+  columns: cols.len(),
+  table.header(..cols.map(c => [*#c*])),
+  ..for i in range(df.at(cols.at(0)).len()) {
+    cols.map(c => [#df.at(c).at(i)])
+  }
+)
 ```
 ````
 
 Python example (in a jupyter chunk):
 
-```python
+````markdown
+```{python}
+#| include: false
 import sys
 sys.path.insert(0, "_extensions/typst-render/_resources")
 from typst_define import typst_define
-import pandas as pd
-typst_define(df = pd.DataFrame({"x": [1, 2, 3]}), label = "hello")
 ```
 
-```typst
-#typst_define.df.x.at(0), #typst_define.label
+```{python}
+#| echo: false
+import pandas as pd
+typst_define(df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), label = "hello")
 ```
+
+```{typst}
+#typst_define.label
+
+#let df = typst_define.df
+#let cols = df.keys()
+#table(
+  columns: cols.len(),
+  table.header(..cols.map(c => [*#c*])),
+  ..for i in range(df.at(cols.at(0)).len()) {
+    cols.map(c => [#df.at(c).at(i)])
+  }
+)
+```
+````
 
 Caveats:
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Use `typst_define()` to push named values from a knitr or jupyter session into e
 Defined values are exposed as a single dict named `typst_define`; access them as `#typst_define.<name>`.
 Supported value types: scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames (column-wise), and numpy arrays.
 
-The helpers ship with the extension under `_extensions/typst-render/_resources/`.
+The helpers ship with the extension under `_extensions/mcanouil/typst-render/_resources/` (once installed).
 Either `source()`/`import` them, or copy-paste the body into a setup chunk.
 
 R example (in a knitr chunk):
@@ -183,7 +183,7 @@ R example (in a knitr chunk):
 ````markdown
 ```{r}
 #| include: false
-source("_extensions/typst-render/_resources/typst_define.R")
+source("_extensions/mcanouil/typst-render/_resources/typst_define.R")
 ```
 
 ```{r}
@@ -212,7 +212,7 @@ Python example (in a jupyter chunk):
 ```{python}
 #| include: false
 import sys
-sys.path.insert(0, "_extensions/typst-render/_resources")
+sys.path.insert(0, "_extensions/mcanouil/typst-render/_resources")
 from typst_define import typst_define
 ```
 

--- a/_extensions/typst-render/_modules/string.lua
+++ b/_extensions/typst-render/_modules/string.lua
@@ -106,7 +106,6 @@ function M.escape_typst(text)
 end
 
 --- Escape characters for Typst string literals (inside `"..."`).
---- Escapes backslash, double quote, newline, carriage return, and tab.
 --- @param text string The text to escape
 --- @return string The escaped text safe for Typst string literals
 function M.escape_typst_string(text)

--- a/_extensions/typst-render/_modules/string.lua
+++ b/_extensions/typst-render/_modules/string.lua
@@ -106,10 +106,16 @@ function M.escape_typst(text)
 end
 
 --- Escape characters for Typst string literals (inside `"..."`).
+--- Escapes backslash, double quote, newline, carriage return, and tab.
 --- @param text string The text to escape
 --- @return string The escaped text safe for Typst string literals
 function M.escape_typst_string(text)
-  return text:gsub('\\', '\\\\'):gsub('"', '\\"')
+  return text
+      :gsub('\\', '\\\\')
+      :gsub('"', '\\"')
+      :gsub('\n', '\\n')
+      :gsub('\r', '\\r')
+      :gsub('\t', '\\t')
 end
 
 --- Escape special Lua pattern characters for use in string.gsub.

--- a/_extensions/typst-render/_resources/typst_define.R
+++ b/_extensions/typst-render/_resources/typst_define.R
@@ -34,23 +34,17 @@ if (requireNamespace("knitr", quietly = TRUE)) {
 #' @return A `knitr::asis_output` object; visible only as a side effect when
 #'   placed in a knitr chunk.
 typst_define <- function(...) {
-  quos <- rlang::enquos(...)
-  vars <- rlang::list2(...)
-  passed_names <- names(vars)
-  if (is.null(passed_names)) passed_names <- rep("", length(vars))
-  inferred <- vapply(quos, rlang::as_label, character(1))
-  nm <- ifelse(nzchar(passed_names), passed_names, inferred)
-  for (i in seq_along(vars)) {
-    .typst_define_state[["entries"]][[nm[i]]] <- vars[[i]]
+  named_vars <- rlang::list2(...)
+  names(named_vars) <- names(rlang::quos_auto_name(rlang::enquos(...)))
+  for (name in names(named_vars)) {
+    .typst_define_state[["entries"]][[name]] <- named_vars[[name]]
   }
   entries <- .typst_define_state[["entries"]]
-  entry_names <- names(entries)
   contents <- jsonlite::toJSON(
-    list(contents = mapply(
+    list(contents = unname(Map(
       function(name, value) list(name = name, value = value),
-      entry_names, entries,
-      SIMPLIFY = FALSE, USE.NAMES = FALSE
-    )),
+      names(entries), entries
+    ))),
     dataframe = "columns",
     null = "null",
     na = "null",
@@ -60,8 +54,8 @@ typst_define <- function(...) {
   # Hex-encode the JSON. Pandoc's smart-quote / dash / ellipsis transforms
   # would otherwise corrupt JSON quotes (`"` -> `“`/`”`) and any `--`/`...`
   # sequences inside string values during metadata block parsing.
-  hex <- paste(as.character(charToRaw(enc2utf8(contents))), collapse = "")
+  encoded <- paste(charToRaw(enc2utf8(contents)), collapse = "")
   knitr::asis_output(paste0(
-    "\n---\ntypst_define: ", hex, "\n---\n"
+    "\n---\ntypst_define: ", encoded, "\n---\n"
   ))
 }

--- a/_extensions/typst-render/_resources/typst_define.R
+++ b/_extensions/typst-render/_resources/typst_define.R
@@ -12,11 +12,22 @@ if (requireNamespace("knitr", quietly = TRUE)) {
   })
 }
 
+#' Session-local accumulator for `typst_define()` payloads.
+#'
+#' Each call to `typst_define()` updates this list (last-write-wins on names,
+#' insertion order preserved) and re-emits the full accumulated payload as a
+#' Pandoc YAML metadata block. Pandoc merges metadata blocks at parse time
+#' (later same-key wins), so the final document metadata sees the largest
+#' accumulator state.
+.typst_define_state <- new.env(parent = emptyenv())
+.typst_define_state[["entries"]] <- list()
+
 #' Pass R values into Typst code cells of the document.
 #'
-#' Emits a `<script type="typst-define">` payload that the typst-render Lua
-#' filter ingests and converts into a `#let typst_define = (...)` binding
-#' available in every `{typst}` code block from that point onward.
+#' Emits a Pandoc YAML metadata block carrying a JSON payload that the
+#' typst-render Lua filter ingests and converts into a
+#' `#let typst_define = (...)` binding available in every `{typst}` code
+#' block from that point onward.
 #'
 #' @param ... Named or positional values.
 #'   Unnamed positional values use the deparsed expression as the key.
@@ -29,10 +40,15 @@ typst_define <- function(...) {
   if (is.null(passed_names)) passed_names <- rep("", length(vars))
   inferred <- vapply(quos, rlang::as_label, character(1))
   nm <- ifelse(nzchar(passed_names), passed_names, inferred)
+  for (i in seq_along(vars)) {
+    .typst_define_state[["entries"]][[nm[i]]] <- vars[[i]]
+  }
+  entries <- .typst_define_state[["entries"]]
+  entry_names <- names(entries)
   contents <- jsonlite::toJSON(
     list(contents = mapply(
       function(name, value) list(name = name, value = value),
-      nm, vars,
+      entry_names, entries,
       SIMPLIFY = FALSE, USE.NAMES = FALSE
     )),
     dataframe = "columns",
@@ -41,8 +57,11 @@ typst_define <- function(...) {
     auto_unbox = TRUE,
     digits = NA
   )
-  contents <- gsub("</", "<\\/", contents, fixed = TRUE)
+  # Hex-encode the JSON. Pandoc's smart-quote / dash / ellipsis transforms
+  # would otherwise corrupt JSON quotes (`"` -> `“`/`”`) and any `--`/`...`
+  # sequences inside string values during metadata block parsing.
+  hex <- paste(as.character(charToRaw(enc2utf8(contents))), collapse = "")
   knitr::asis_output(paste0(
-    '<script type="typst-define">', contents, "</script>"
+    "\n---\ntypst_define: ", hex, "\n---\n"
   ))
 }

--- a/_extensions/typst-render/_resources/typst_define.R
+++ b/_extensions/typst-render/_resources/typst_define.R
@@ -1,0 +1,34 @@
+#' Pass R values into Typst code cells of the document.
+#'
+#' Emits a `<script type="typst-define">` payload that the typst-render Lua
+#' filter ingests and converts into a `#let typst_define = (...)` binding
+#' available in every `{typst}` code block from that point onward.
+#'
+#' @param ... Named or positional values.
+#'   Unnamed positional values use the deparsed expression as the key.
+#' @return A `knitr::asis_output` object; visible only as a side effect when
+#'   placed in a knitr chunk.
+typst_define <- function(...) {
+  quos <- rlang::enquos(...)
+  vars <- rlang::list2(...)
+  passed_names <- names(vars)
+  if (is.null(passed_names)) passed_names <- rep("", length(vars))
+  inferred <- vapply(quos, rlang::as_label, character(1))
+  nm <- ifelse(nzchar(passed_names), passed_names, inferred)
+  contents <- jsonlite::toJSON(
+    list(contents = mapply(
+      function(name, value) list(name = name, value = value),
+      nm, vars,
+      SIMPLIFY = FALSE, USE.NAMES = FALSE
+    )),
+    dataframe = "columns",
+    null = "null",
+    na = "null",
+    auto_unbox = TRUE,
+    digits = NA
+  )
+  contents <- gsub("</", "<\\/", contents, fixed = TRUE)
+  knitr::asis_output(paste0(
+    '<script type="typst-define">', contents, "</script>"
+  ))
+}

--- a/_extensions/typst-render/_resources/typst_define.R
+++ b/_extensions/typst-render/_resources/typst_define.R
@@ -1,3 +1,17 @@
+#' Register a passthrough knitr engine for `{typst}` code blocks.
+#'
+#' Without this, knitr emits "Unknown language engine 'typst'" warnings and
+#' wraps the block in a cell-output div with a `typst` (singular) class. The
+#' engine simply re-emits the chunk source as a `` ```{typst} `` fenced block
+#' so pandoc sees the literal `{typst}` class that the typst-render filter
+#' expects.
+if (requireNamespace("knitr", quietly = TRUE)) {
+  knitr::knit_engines$set(typst = function(options) {
+    code <- paste(options[["code"]], collapse = "\n")
+    knitr::asis_output(paste0("\n```{typst}\n", code, "\n```\n"))
+  })
+}
+
 #' Pass R values into Typst code cells of the document.
 #'
 #' Emits a `<script type="typst-define">` payload that the typst-render Lua

--- a/_extensions/typst-render/_resources/typst_define.py
+++ b/_extensions/typst-render/_resources/typst_define.py
@@ -1,14 +1,21 @@
 """Pass Python values into Typst code cells of the document.
 
-Emits a <script type="typst-define"> payload that the typst-render Lua filter
-ingests and converts into a `#let typst_define = (...)` binding available in
-every `{typst}` code block from that point onward.
+Emits a Pandoc YAML metadata block carrying a JSON payload that the
+typst-render Lua filter ingests and converts into a `#let typst_define = (...)`
+binding available in every `{typst}` code block from that point onward.
 """
+
+# Session-local accumulator. Each call updates this dict (last-write-wins on
+# names, insertion order preserved per Python 3.7+) and re-emits the full
+# accumulated payload as a metadata block. Pandoc merges metadata blocks at
+# parse time (later same-key wins), so the final document metadata sees the
+# largest accumulator state.
+_typst_define_state = {}
 
 
 def typst_define(**kwargs):
     import json
-    from IPython.display import display, HTML
+    from IPython.display import display, Markdown
 
     def _convert(v):
         try:
@@ -31,10 +38,16 @@ def typst_define(**kwargs):
             pass
         return v
 
+    for k, v in kwargs.items():
+        _typst_define_state[k] = _convert(v)
     payload = {
         "contents": [
-            {"name": k, "value": _convert(v)} for k, v in kwargs.items()
+            {"name": k, "value": v} for k, v in _typst_define_state.items()
         ]
     }
-    payload_str = json.dumps(payload).replace("</", "<\\/")
-    display(HTML(f'<script type="typst-define">{payload_str}</script>'))
+    json_str = json.dumps(payload)
+    # Hex-encode the JSON. Pandoc's smart-quote / dash / ellipsis transforms
+    # would otherwise corrupt JSON quotes (`"` -> `“`/`”`) and any `--`/`...`
+    # sequences inside string values during metadata block parsing.
+    hex = json_str.encode("utf-8").hex()
+    display(Markdown(f"\n---\ntypst_define: {hex}\n---\n"))

--- a/_extensions/typst-render/_resources/typst_define.py
+++ b/_extensions/typst-render/_resources/typst_define.py
@@ -1,42 +1,39 @@
 """Pass Python values into Typst code cells of the document.
 
-Emits a Pandoc YAML metadata block carrying a JSON payload that the
-typst-render Lua filter ingests and converts into a `#let typst_define = (...)`
-binding available in every `{typst}` code block from that point onward.
+Emits a Pandoc YAML metadata block carrying a hex-encoded JSON payload that
+the typst-render Lua filter ingests and converts into a
+`#let typst_define = (...)` binding available in every `{typst}` code block
+from that point onward.
 """
 
-# Session-local accumulator. Each call updates this dict (last-write-wins on
+import importlib
+
+# Across-call accumulator. Each call updates this dict (last-write-wins on
 # names, insertion order preserved per Python 3.7+) and re-emits the full
-# accumulated payload as a metadata block. Pandoc merges metadata blocks at
-# parse time (later same-key wins), so the final document metadata sees the
-# largest accumulator state.
+# accumulated payload so pandoc's metadata-block merge ends up with the
+# right final state.
 _typst_define_state = {}
+
+
+def _convert(v):
+    """Convert pandas/polars/numpy values to JSON-serialisable forms."""
+    converters = (
+        ("pandas", "DataFrame", lambda x: x.to_dict(orient="list")),
+        ("polars", "DataFrame", lambda x: x.to_dict(as_series=False)),
+        ("numpy", "ndarray", lambda x: x.tolist()),
+    )
+    for module_name, type_name, convert in converters:
+        if importlib.util.find_spec(module_name) is None:
+            continue
+        module = importlib.import_module(module_name)
+        if isinstance(v, getattr(module, type_name)):
+            return convert(v)
+    return v
 
 
 def typst_define(**kwargs):
     import json
     from IPython.display import display, Markdown
-
-    def _convert(v):
-        try:
-            import pandas as pd
-            if isinstance(v, pd.DataFrame):
-                return v.to_dict(orient="list")
-        except ImportError:
-            pass
-        try:
-            import polars as pl
-            if isinstance(v, pl.DataFrame):
-                return v.to_dict(as_series=False)
-        except ImportError:
-            pass
-        try:
-            import numpy as np
-            if isinstance(v, np.ndarray):
-                return v.tolist()
-        except ImportError:
-            pass
-        return v
 
     for k, v in kwargs.items():
         _typst_define_state[k] = _convert(v)
@@ -45,9 +42,5 @@ def typst_define(**kwargs):
             {"name": k, "value": v} for k, v in _typst_define_state.items()
         ]
     }
-    json_str = json.dumps(payload)
-    # Hex-encode the JSON. Pandoc's smart-quote / dash / ellipsis transforms
-    # would otherwise corrupt JSON quotes (`"` -> `“`/`”`) and any `--`/`...`
-    # sequences inside string values during metadata block parsing.
-    hex = json_str.encode("utf-8").hex()
-    display(Markdown(f"\n---\ntypst_define: {hex}\n---\n"))
+    encoded = json.dumps(payload).encode("utf-8").hex()
+    display(Markdown(f"\n---\ntypst_define: {encoded}\n---\n"))

--- a/_extensions/typst-render/_resources/typst_define.py
+++ b/_extensions/typst-render/_resources/typst_define.py
@@ -1,0 +1,40 @@
+"""Pass Python values into Typst code cells of the document.
+
+Emits a <script type="typst-define"> payload that the typst-render Lua filter
+ingests and converts into a `#let typst_define = (...)` binding available in
+every `{typst}` code block from that point onward.
+"""
+
+
+def typst_define(**kwargs):
+    import json
+    from IPython.display import display, HTML
+
+    def _convert(v):
+        try:
+            import pandas as pd
+            if isinstance(v, pd.DataFrame):
+                return v.to_dict(orient="list")
+        except ImportError:
+            pass
+        try:
+            import polars as pl
+            if isinstance(v, pl.DataFrame):
+                return v.to_dict(as_series=False)
+        except ImportError:
+            pass
+        try:
+            import numpy as np
+            if isinstance(v, np.ndarray):
+                return v.tolist()
+        except ImportError:
+            pass
+        return v
+
+    payload = {
+        "contents": [
+            {"name": k, "value": _convert(v)} for k, v in kwargs.items()
+        ]
+    }
+    payload_str = json.dumps(payload).replace("</", "<\\/")
+    display(HTML(f'<script type="typst-define">{payload_str}</script>'))

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -145,33 +145,27 @@ local typst_define_dict = {}
 local typst_define_order = {}
 
 -- ============================================================================
--- TYPST DEFINE — INGEST FROM <script type="typst-define"> PAYLOADS
+-- TYPST DEFINE — INGEST FROM `typst_define:` METADATA BLOCK
 -- ============================================================================
 
---- Lua pattern matching the script tag wrapper.
---- `.-` is lazy and `.` matches newlines, so multi-line JSON payloads work.
-local TYPST_DEFINE_SCRIPT_PAT = '<script%s+type="typst%-define"%s*>(.-)</script>'
-
---- Extract the JSON payload from a raw HTML string, if present.
---- @param text string Raw HTML text
---- @return string|nil JSON payload or nil
-local function extract_typst_define(text)
-  if not text then return nil end
-  return text:match(TYPST_DEFINE_SCRIPT_PAT)
-end
-
---- Detect whether a Pandoc Raw* element format is HTML.
---- Accepts "html" and "html5" / similar variants.
---- @param fmt string|nil
---- @return boolean
-local function is_html_format(fmt)
-  if fmt == nil then return false end
-  return fmt == 'html' or (type(fmt) == 'string' and fmt:match('^html'))
+--- Decode a hex-encoded UTF-8 string back to its raw bytes.
+--- The R/Python helpers hex-encode the JSON payload so pandoc's smart-quote
+--- transforms cannot corrupt JSON quotes or string-content `--`/`...`.
+--- @param hex string Hex string (lowercase or uppercase, no separators)
+--- @return string|nil Decoded string, or nil on malformed input
+local function hex_decode(hex)
+  if type(hex) ~= 'string' then return nil end
+  if #hex % 2 ~= 0 then return nil end
+  local out, ok = hex:gsub('(%x%x)', function(byte)
+    return string.char(tonumber(byte, 16))
+  end)
+  if ok ~= #hex / 2 then return nil end
+  return out
 end
 
 --- Decode a JSON payload and merge its `contents` into the document-wide dict.
 --- Last-write-wins on duplicate names; first-seen index in declaration order.
---- @param json_str string JSON payload from a typst-define script tag
+--- @param json_str string JSON payload carried by the metadata block
 local function ingest_define_payload(json_str)
   local ok, parsed = pcall(pandoc.json.decode, json_str)
   if not ok or type(parsed) ~= 'table' or type(parsed.contents) ~= 'table' then
@@ -1485,6 +1479,22 @@ local function get_configuration(meta)
     end
   end
 
+  -- Ingest any `typst_define:` payload emitted by the R/Python helpers.
+  -- The helpers write a YAML metadata block whose value is a hex-encoded
+  -- JSON payload; we hex-decode, JSON-decode, and strip the key so it does
+  -- not leak to downstream filters.
+  local define_meta = meta['typst_define']
+  if define_meta then
+    local hex = pandoc.utils.stringify(define_meta)
+    local json_str = hex and hex_decode(hex)
+    if json_str and json_str ~= '' then
+      ingest_define_payload(json_str)
+    elseif hex and hex ~= '' then
+      log.log_warning(EXTENSION_NAME, 'typst_define metadata payload is not valid hex; ignoring.')
+    end
+    meta['typst_define'] = nil
+  end
+
   return meta
 end
 
@@ -1931,32 +1941,7 @@ end
 -- FILTER EXPORT
 -- ============================================================================
 
---- First-pass filter: ingest <script type="typst-define"> payloads emitted by
---- engine-side `typst_define()` helpers and strip them from the AST so they do
---- not leak into the rendered output.
-local typst_define_collect = {
-  RawBlock = function(el)
-    if is_html_format(el.format) then
-      local payload = extract_typst_define(el.text)
-      if payload then
-        ingest_define_payload(payload)
-        return {}
-      end
-    end
-  end,
-  RawInline = function(el)
-    if is_html_format(el.format) then
-      local payload = extract_typst_define(el.text)
-      if payload then
-        ingest_define_payload(payload)
-        return {}
-      end
-    end
-  end,
-}
-
 return {
-  typst_define_collect,
   { Meta = get_configuration },
   { CodeBlock = process_codeblock, Code = process_inline_code },
   { Pandoc = cleanup_cache },

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -137,6 +137,118 @@ local used_cache_formats = {}
 --- Cache of file contents read during this render pass (keyed by absolute path)
 local read_file_cache = {}
 
+--- Document-wide `typst_define()` payload, accumulated by the collect pass.
+--- Maps name -> raw value (Lua representation of the JSON-decoded payload).
+local typst_define_dict = {}
+
+--- Declaration order of names in `typst_define_dict`, preserved across calls.
+local typst_define_order = {}
+
+-- ============================================================================
+-- TYPST DEFINE — INGEST FROM <script type="typst-define"> PAYLOADS
+-- ============================================================================
+
+--- Lua pattern matching the script tag wrapper.
+--- `.-` is lazy and `.` matches newlines, so multi-line JSON payloads work.
+local TYPST_DEFINE_SCRIPT_PAT = '<script%s+type="typst%-define"%s*>(.-)</script>'
+
+--- Extract the JSON payload from a raw HTML string, if present.
+--- @param text string Raw HTML text
+--- @return string|nil JSON payload or nil
+local function extract_typst_define(text)
+  if not text then return nil end
+  return text:match(TYPST_DEFINE_SCRIPT_PAT)
+end
+
+--- Detect whether a Pandoc Raw* element format is HTML.
+--- Accepts "html" and "html5" / similar variants.
+--- @param fmt string|nil
+--- @return boolean
+local function is_html_format(fmt)
+  if fmt == nil then return false end
+  return fmt == 'html' or (type(fmt) == 'string' and fmt:match('^html'))
+end
+
+--- Decode a JSON payload and merge its `contents` into the document-wide dict.
+--- Last-write-wins on duplicate names; first-seen index in declaration order.
+--- @param json_str string JSON payload from a typst-define script tag
+local function ingest_define_payload(json_str)
+  local ok, parsed = pcall(pandoc.json.decode, json_str)
+  if not ok or type(parsed) ~= 'table' or type(parsed.contents) ~= 'table' then
+    log.log_warning(EXTENSION_NAME, 'Failed to decode typst-define payload; ignoring.')
+    return
+  end
+  for _, entry in ipairs(parsed.contents) do
+    if type(entry) == 'table' and entry.name then
+      if typst_define_dict[entry.name] == nil then
+        typst_define_order[#typst_define_order + 1] = entry.name
+      end
+      typst_define_dict[entry.name] = entry.value
+    end
+  end
+end
+
+-- ============================================================================
+-- TYPST DEFINE — JSON → TYPST LITERAL CONVERSION
+-- ============================================================================
+
+--- Format a Lua number for Typst output.
+--- Integers print without a decimal point; doubles use `%.17g` for lossless
+--- round-trip of the original IEEE-754 value.
+--- @param n number
+--- @return string
+local function format_number(n)
+  if math.type(n) == 'integer' then return tostring(n) end
+  return string.format('%.17g', n)
+end
+
+--- Detect whether a value is a `pandoc.List` (used for JSON arrays).
+--- @param v any
+--- @return boolean
+local function is_pandoc_list(v)
+  return pandoc.utils.type(v) == 'List'
+end
+
+--- Convert a JSON-decoded Lua value to a Typst literal source fragment.
+--- @param v any Decoded value (nil/boolean/number/string/table/pandoc.List/pandoc.json.null)
+--- @return string Typst source
+local function to_typst_literal(v)
+  if v == nil or v == pandoc.json.null then return 'none' end
+  local t = type(v)
+  if t == 'boolean' then return tostring(v) end
+  if t == 'number' then return format_number(v) end
+  if t == 'string' then return '"' .. str.escape_typst_string(v) .. '"' end
+  if t == 'table' then
+    if is_pandoc_list(v) then
+      local parts = {}
+      for _, x in ipairs(v) do parts[#parts + 1] = to_typst_literal(x) end
+      if #parts == 0 then return '()' end
+      if #parts == 1 then return '(' .. parts[1] .. ',)' end
+      return '(' .. table.concat(parts, ', ') .. ')'
+    end
+    local parts = {}
+    for k, x in pairs(v) do
+      parts[#parts + 1] = '"' .. str.escape_typst_string(tostring(k)) .. '": ' .. to_typst_literal(x)
+    end
+    if #parts == 0 then return '(:)' end
+    return '(' .. table.concat(parts, ', ') .. ')'
+  end
+  return 'none'
+end
+
+--- Build the `#let typst_define = (...)` preamble line from accumulated payloads.
+--- Returns nil when no `typst_define()` call has been ingested.
+--- @return string|nil
+local function build_define_preamble()
+  if #typst_define_order == 0 then return nil end
+  local parts = {}
+  for _, name in ipairs(typst_define_order) do
+    parts[#parts + 1] = '"' .. str.escape_typst_string(name) .. '": '
+        .. to_typst_literal(typst_define_dict[name])
+  end
+  return '#let typst_define = (' .. table.concat(parts, ', ') .. ')'
+end
+
 -- ============================================================================
 -- BRAND / THEME COLOUR RESOLUTION
 -- ============================================================================
@@ -621,6 +733,10 @@ end
 local function build_typst_source(code, opts)
   local parts = {}
   inject_colour_vars(parts, opts)
+  local define_preamble = build_define_preamble()
+  if define_preamble then
+    parts[#parts + 1] = define_preamble
+  end
   parts[#parts + 1] = build_page_directive(opts)
   if opts.foreground then
     parts[#parts + 1] = '#set text(fill: ' .. opts.foreground .. ')'
@@ -1450,6 +1566,10 @@ local function process_codeblock(el)
     local preamble = resolve_preamble(typst_opts.preamble)
     local parts = {}
     inject_colour_vars(parts, typst_opts)
+    local define_preamble = build_define_preamble()
+    if define_preamble then
+      parts[#parts + 1] = define_preamble
+    end
     if typst_opts.foreground then
       parts[#parts + 1] = '#set text(fill: ' .. typst_opts.foreground .. ')'
     end
@@ -1801,7 +1921,32 @@ end
 -- FILTER EXPORT
 -- ============================================================================
 
+--- First-pass filter: ingest <script type="typst-define"> payloads emitted by
+--- engine-side `typst_define()` helpers and strip them from the AST so they do
+--- not leak into the rendered output.
+local typst_define_collect = {
+  RawBlock = function(el)
+    if is_html_format(el.format) then
+      local payload = extract_typst_define(el.text)
+      if payload then
+        ingest_define_payload(payload)
+        return {}
+      end
+    end
+  end,
+  RawInline = function(el)
+    if is_html_format(el.format) then
+      local payload = extract_typst_define(el.text)
+      if payload then
+        ingest_define_payload(payload)
+        return {}
+      end
+    end
+  end,
+}
+
 return {
+  typst_define_collect,
   { Meta = get_configuration },
   { CodeBlock = process_codeblock, Code = process_inline_code },
   { Pandoc = cleanup_cache },

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -226,9 +226,14 @@ local function to_typst_literal(v)
       if #parts == 1 then return '(' .. parts[1] .. ',)' end
       return '(' .. table.concat(parts, ', ') .. ')'
     end
-    local parts = {}
+    local entries = {}
     for k, x in pairs(v) do
-      parts[#parts + 1] = '"' .. str.escape_typst_string(tostring(k)) .. '": ' .. to_typst_literal(x)
+      entries[#entries + 1] = { key = tostring(k), value = x }
+    end
+    table.sort(entries, function(a, b) return a.key < b.key end)
+    local parts = {}
+    for _, e in ipairs(entries) do
+      parts[#parts + 1] = '"' .. str.escape_typst_string(e.key) .. '": ' .. to_typst_literal(e.value)
     end
     if #parts == 0 then return '(:)' end
     return '(' .. table.concat(parts, ', ') .. ')'
@@ -1913,6 +1918,11 @@ local function cleanup_cache(doc) -- luacheck: ignore 212
       'Cache cleanup: removed ' .. removed .. ' stale file(s).'
     )
   end
+
+  -- Reset typst_define state in case the Lua VM is reused for another document
+  -- (e.g. batch render). Each document's payloads must not leak into the next.
+  typst_define_dict = {}
+  typst_define_order = {}
 
   return nil
 end

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -144,23 +144,26 @@ local typst_define_dict = {}
 --- Declaration order of names in `typst_define_dict`, preserved across calls.
 local typst_define_order = {}
 
+--- Cached preamble line; built once per Meta pass after ingestion completes,
+--- then reused for every {typst} block in this render.
+local typst_define_preamble_cache = nil
+
 -- ============================================================================
 -- TYPST DEFINE — INGEST FROM `typst_define:` METADATA BLOCK
 -- ============================================================================
 
 --- Decode a hex-encoded UTF-8 string back to its raw bytes.
---- The R/Python helpers hex-encode the JSON payload so pandoc's smart-quote
---- transforms cannot corrupt JSON quotes or string-content `--`/`...`.
+--- WHY: pandoc's smart-quote, dash, and ellipsis transforms would corrupt the
+--- JSON payload during YAML metadata block parsing. Hex is transform-free.
 --- @param hex string Hex string (lowercase or uppercase, no separators)
 --- @return string|nil Decoded string, or nil on malformed input
 local function hex_decode(hex)
   if type(hex) ~= 'string' then return nil end
   if #hex % 2 ~= 0 then return nil end
-  local out, ok = hex:gsub('(%x%x)', function(byte)
+  if hex:match('[^%x]') then return nil end
+  return (hex:gsub('(%x%x)', function(byte)
     return string.char(tonumber(byte, 16))
-  end)
-  if ok ~= #hex / 2 then return nil end
-  return out
+  end))
 end
 
 --- Decode a JSON payload and merge its `contents` into the document-wide dict.
@@ -235,17 +238,21 @@ local function to_typst_literal(v)
   return 'none'
 end
 
---- Build the `#let typst_define = (...)` preamble line from accumulated payloads.
---- Returns nil when no `typst_define()` call has been ingested.
+--- Build the `#let typst_define = (...)` preamble line from accumulated
+--- payloads, memoised across all blocks in a single render.
 --- @return string|nil
 local function build_define_preamble()
+  if typst_define_preamble_cache ~= nil then
+    return typst_define_preamble_cache
+  end
   if #typst_define_order == 0 then return nil end
   local parts = {}
   for _, name in ipairs(typst_define_order) do
     parts[#parts + 1] = '"' .. str.escape_typst_string(name) .. '": '
         .. to_typst_literal(typst_define_dict[name])
   end
-  return '#let typst_define = (' .. table.concat(parts, ', ') .. ')'
+  typst_define_preamble_cache = '#let typst_define = (' .. table.concat(parts, ', ') .. ')'
+  return typst_define_preamble_cache
 end
 
 -- ============================================================================
@@ -1933,6 +1940,7 @@ local function cleanup_cache(doc) -- luacheck: ignore 212
   -- (e.g. batch render). Each document's payloads must not leak into the next.
   typst_define_dict = {}
   typst_define_order = {}
+  typst_define_preamble_cache = nil
 
   return nil
 end

--- a/example.qmd
+++ b/example.qmd
@@ -390,7 +390,7 @@ source("_extensions/typst-render/_resources/typst_define.R")
 ```
 
 ```{r}
-#| echo: false
+#| output: asis
 typst_define(mtcars = head(mtcars)[, c("mpg", "cyl", "hp")], n = 42L)
 ```
 
@@ -420,7 +420,7 @@ from typst_define import typst_define
 ```
 
 ```{python}
-#| echo: false
+#| output: asis
 import pandas as pd
 typst_define(df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), label = "hello")
 ```

--- a/example.qmd
+++ b/example.qmd
@@ -385,13 +385,27 @@ R (knitr engine):
 
 ````markdown
 ```{r}
-#| echo: false
+#| include: false
 source("_extensions/typst-render/_resources/typst_define.R")
-typst_define(mtcars = head(mtcars), n = 42L)
+```
+
+```{r}
+#| echo: false
+typst_define(mtcars = head(mtcars)[, c("mpg", "cyl", "hp")], n = 42L)
 ```
 
 ```{typst}
-First mpg: #typst_define.mtcars.mpg.at(0), n = #typst_define.n
+n = #typst_define.n
+
+#let df = typst_define.mtcars
+#let cols = df.keys()
+#table(
+  columns: cols.len(),
+  table.header(..cols.map(c => [*#c*])),
+  ..for i in range(df.at(cols.at(0)).len()) {
+    cols.map(c => [#df.at(c).at(i)])
+  }
+)
 ```
 ````
 
@@ -399,16 +413,30 @@ Python (jupyter engine):
 
 ````markdown
 ```{python}
-#| echo: false
+#| include: false
 import sys
 sys.path.insert(0, "_extensions/typst-render/_resources")
 from typst_define import typst_define
+```
+
+```{python}
+#| echo: false
 import pandas as pd
-typst_define(df = pd.DataFrame({"x": [1, 2, 3]}), label = "hello")
+typst_define(df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), label = "hello")
 ```
 
 ```{typst}
-#typst_define.df.x.at(0), #typst_define.label
+#typst_define.label
+
+#let df = typst_define.df
+#let cols = df.keys()
+#table(
+  columns: cols.len(),
+  table.header(..cols.map(c => [*#c*])),
+  ..for i in range(df.at(cols.at(0)).len()) {
+    cols.map(c => [#df.at(c).at(i)])
+  }
+)
 ```
 ````
 

--- a/example.qmd
+++ b/example.qmd
@@ -372,21 +372,19 @@ Global inputs are set in YAML; per-block inputs override them using comma-separa
 
 ## Passing Data from R/Python
 
-::: {.content-hidden when-format="typst"}
-
 Use `typst_define()` to push named values from a knitr or jupyter session into every `{typst}` cell.
 Defined values are exposed as `#typst_define.<name>`.
 Supports scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames, and numpy arrays.
 
 This document uses the markdown engine; the snippets below are illustrative.
-For an executable demo, switch the document `engine` to `knitr` (R) or `jupyter` (Python) and copy the helper from `_extensions/typst-render/_resources/typst_define.R` or `typst_define.py`.
+For an executable demo, switch the document `engine` to `knitr` (R) or `jupyter` (Python) and copy the helper from `_extensions/mcanouil/typst-render/_resources/` (once installed): `typst_define.R` or `typst_define.py`.
 
 R (knitr engine):
 
 ````markdown
 ```{r}
 #| include: false
-source("_extensions/typst-render/_resources/typst_define.R")
+source("_extensions/mcanouil/typst-render/_resources/typst_define.R")
 ```
 
 ```{r}
@@ -415,7 +413,7 @@ Python (jupyter engine):
 ```{python}
 #| include: false
 import sys
-sys.path.insert(0, "_extensions/typst-render/_resources")
+sys.path.insert(0, "_extensions/mcanouil/typst-render/_resources")
 from typst_define import typst_define
 ```
 
@@ -439,8 +437,6 @@ typst_define(df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}), label = "hello
 )
 ```
 ````
-
-:::
 
 ## Multi-Page Output
 

--- a/example.qmd
+++ b/example.qmd
@@ -370,6 +370,50 @@ Global inputs are set in YAML; per-block inputs override them using comma-separa
 
 :::
 
+## Passing Data from R/Python
+
+::: {.content-hidden when-format="typst"}
+
+Use `typst_define()` to push named values from a knitr or jupyter session into every `{typst}` cell.
+Defined values are exposed as `#typst_define.<name>`.
+Supports scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames, and numpy arrays.
+
+This document uses the markdown engine; the snippets below are illustrative.
+For an executable demo, switch the document `engine` to `knitr` (R) or `jupyter` (Python) and copy the helper from `_extensions/typst-render/_resources/typst_define.R` or `typst_define.py`.
+
+R (knitr engine):
+
+````markdown
+```{r}
+#| echo: false
+source("_extensions/typst-render/_resources/typst_define.R")
+typst_define(mtcars = head(mtcars), n = 42L)
+```
+
+```{typst}
+First mpg: #typst_define.mtcars.mpg.at(0), n = #typst_define.n
+```
+````
+
+Python (jupyter engine):
+
+````markdown
+```{python}
+#| echo: false
+import sys
+sys.path.insert(0, "_extensions/typst-render/_resources")
+from typst_define import typst_define
+import pandas as pd
+typst_define(df = pd.DataFrame({"x": [1, 2, 3]}), label = "hello")
+```
+
+```{typst}
+#typst_define.df.x.at(0), #typst_define.label
+```
+````
+
+:::
+
 ## Multi-Page Output
 
 When Typst produces multiple pages, all pages are included by default.


### PR DESCRIPTION
Adds `typst_define()` helpers (R and Python) that push named values from a knitr or jupyter session into every `{typst}` cell of the document.
Defined values are exposed as a single dict named `typst_define` accessed as `#typst_define.<name>`.

The R helper uses `jsonlite` and `knitr::asis_output()`; the Python helper uses `IPython.display(HTML(...))`.
Each call emits a `<script type="typst-define">{json}</script>` payload into the rendered markdown.
The Lua filter walks the Pandoc AST, ingests payloads, strips them, parses the JSON with `pandoc.json.decode`, converts to a Typst dict literal, and prepends `#let typst_define = (...)` to every compiled Typst source via `build_typst_source()`.
The native typst output path also receives the preamble.

The cache hash includes the preamble, so any change to defined data invalidates affected cells.
`</` sequences in payload values are escaped to `<\/` to prevent HTML-context script-tag closure injection.
Dict keys are sorted before emission for deterministic cache hashes.
Module state is reset in the Pandoc cleanup pass so reused Lua VMs do not leak payloads across documents.

Supported value types: scalars, strings, booleans, arrays, nested objects, R data frames (column-wise), pandas/polars DataFrames, and numpy arrays.

Helpers ship under `_extensions/typst-render/_resources/typst_define.R` and `typst_define.py`.
README and `example.qmd` document loading recipes and caveats (define-before-use, identifier-named keys, `freeze` interaction).