### PR TITLE
refactor: rename typst_define metadata key to typst-define

### DIFF
--- a/_extensions/typst-render/_resources/typst_define.R
+++ b/_extensions/typst-render/_resources/typst_define.R
@@ -56,6 +56,6 @@ typst_define <- function(...) {
   # sequences inside string values during metadata block parsing.
   encoded <- paste(charToRaw(enc2utf8(contents)), collapse = "")
   knitr::asis_output(paste0(
-    "\n---\ntypst_define: ", encoded, "\n---\n"
+    "\n---\ntypst-define: ", encoded, "\n---\n"
   ))
 }

--- a/_extensions/typst-render/_resources/typst_define.py
+++ b/_extensions/typst-render/_resources/typst_define.py
@@ -43,4 +43,4 @@ def typst_define(**kwargs):
         ]
     }
     encoded = json.dumps(payload).encode("utf-8").hex()
-    display(Markdown(f"\n---\ntypst_define: {encoded}\n---\n"))
+    display(Markdown(f"\n---\ntypst-define: {encoded}\n---\n"))

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -149,7 +149,7 @@ local typst_define_order = {}
 local typst_define_preamble_cache = nil
 
 -- ============================================================================
--- TYPST DEFINE — INGEST FROM `typst_define:` METADATA BLOCK
+-- TYPST DEFINE — INGEST FROM `typst-define:` METADATA BLOCK
 -- ============================================================================
 
 --- Decode a hex-encoded UTF-8 string back to its raw bytes.
@@ -1486,20 +1486,20 @@ local function get_configuration(meta)
     end
   end
 
-  -- Ingest any `typst_define:` payload emitted by the R/Python helpers.
+  -- Ingest any `typst-define:` payload emitted by the R/Python helpers.
   -- The helpers write a YAML metadata block whose value is a hex-encoded
   -- JSON payload; we hex-decode, JSON-decode, and strip the key so it does
   -- not leak to downstream filters.
-  local define_meta = meta['typst_define']
+  local define_meta = meta['typst-define']
   if define_meta then
     local hex = pandoc.utils.stringify(define_meta)
     local json_str = hex and hex_decode(hex)
     if json_str and json_str ~= '' then
       ingest_define_payload(json_str)
     elseif hex and hex ~= '' then
-      log.log_warning(EXTENSION_NAME, 'typst_define metadata payload is not valid hex; ignoring.')
+      log.log_warning(EXTENSION_NAME, 'typst-define metadata payload is not valid hex; ignoring.')
     end
-    meta['typst_define'] = nil
+    meta['typst-define'] = nil
   end
 
   return meta


### PR DESCRIPTION
Rename the YAML transport key emitted by the R and Python `typst_define()` helpers and read by the Lua filter from `typst_define:` to `typst-define:` so the document-level metadata key follows Quarto's kebab-case convention. The user-facing function name `typst_define()`, the Typst-side dict identifier `#typst_define`, internal Lua locals, and resource filenames are unchanged because they live in namespaces where snake_case is idiomatic or where dashes are not valid identifiers.