### PR TITLE
fix: propagate alt text to cross-referenced images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: the `alt` (and `<prefix>-alt`) cell option was not propagated to the rendered image when the block carried a cross-reference label. The alt text lived only in the image caption inlines, which Quarto's figure pipeline discards once the image is wrapped in a `FloatRefTarget`. The alt text is now also emitted as a `fig-alt` attribute on the image, so it reaches the `<img alt>` (HTML), `\includegraphics[alt=...]` (LaTeX), and `image(alt: ...)` (Typst) outputs.
+
 ## 0.13.1 (2026-05-14)
 
 - no user-facing changes.

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1195,6 +1195,14 @@ local function create_image_element(img_path, opts)
     end
   end
 
+  -- Carry the alt text as `fig-alt` so Quarto's figure pipeline copies it onto
+  -- the rendered `<img alt>` (and LaTeX/Typst equivalents). When the image is
+  -- wrapped in a FloatRefTarget, its caption inlines are consumed as the
+  -- caption, so the attribute is the only path that reaches the image alt.
+  if alt_text ~= '' then
+    kvpairs[#kvpairs + 1] = { 'fig-alt', alt_text }
+  end
+
   local img = pandoc.Image(
     { pandoc.Str(alt_text) },
     img_path,


### PR DESCRIPTION
When a {typst} block carries a cross-reference label, the alt text was stored only in the image caption inlines. Quarto's figure pipeline discards those inlines once the image is wrapped in a FloatRefTarget, so the rendered image had no alt text.

The resolved alt is now also emitted as a `fig-alt` attribute on the image. Quarto copies that onto the `<img alt>` for HTML, `\includegraphics[alt=...]` for LaTeX, and `image(alt: ...)` for Typst. The `alt` and `<prefix>-alt` cell options both feed this attribute, verified across HTML, docx, LaTeX, and Typst output.