### PR TITLE
fix: compute include:false blocks instead of skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: `include: false` now compiles the block and writes output files (matching Quarto semantics) while embedding nothing in the document, instead of skipping compilation entirely. Use `eval: false` to skip computation.
+
 ## 0.13.2 (2026-05-23)
 
 ### Bug Fixes

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -97,7 +97,7 @@ options:
   include:
     type: boolean
     default: true
-    description: "Include block in output. Set false to suppress entirely."
+    description: "Embed block output in the document. Set false to still compile and write output files, but embed nothing."
   output:
     type: [boolean, string]
     enum: [true, false, asis]
@@ -191,7 +191,7 @@ attributes:
       description: "Compile this block to image."
     include:
       type: boolean
-      description: "Include this block in output. Set false to suppress entirely."
+      description: "Embed this block's output in the document. Set false to still compile and write output files, but embed nothing."
     output:
       type: [boolean, string]
       enum: [true, false, asis]

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1,5 +1,5 @@
 --- Typst Render - Filter
---- @module typst-render
+--- @module "typst-render"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
@@ -1552,10 +1552,7 @@ local function process_codeblock(el)
     end
   end
 
-  if not cell.should_include(opts) then
-    return pandoc.Null()
-  end
-
+  local do_include = cell.should_include(opts)
   local do_eval = opts.eval ~= false
   local do_echo = opts.echo == true or opts.echo == 'fenced'
   local is_fenced = opts.echo == 'fenced'
@@ -1577,12 +1574,15 @@ local function process_codeblock(el)
 
   -- Echo-only: show source listing without compilation
   if not do_eval then
+    if not do_include then
+      return pandoc.Null()
+    end
     return cell.create_echo_block(code, is_fenced, option_lines)
   end
 
   -- Output suppressed: skip compilation, show echo block only
   if output_mode == 'false' then
-    if do_echo then
+    if do_echo and do_include then
       return cell.create_echo_block(code, is_fenced, option_lines)
     end
     return pandoc.Null()
@@ -1590,6 +1590,9 @@ local function process_codeblock(el)
 
   -- Native Typst output: pass through as scoped RawBlock, wrapped in crossref if needed
   if quarto.format.is_typst_output() and output_mode == 'asis' then
+    if not do_include then
+      return pandoc.Null()
+    end
     local typst_opts = has_dual_mode_colours(opts)
         and resolve_opts_colours(opts, global_brand_mode)
         or opts
@@ -1671,6 +1674,9 @@ local function process_codeblock(el)
 
     if not light_content and not dark_content then
       log.log_warning(EXTENSION_NAME, 'Compilation failed; returning error block.')
+      if not do_include then
+        return pandoc.Null()
+      end
       local error_block = create_error_block(light_err or dark_err)
       if do_echo then
         local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
@@ -1725,6 +1731,9 @@ local function process_codeblock(el)
     if not content then
       if compile_err then
         log.log_warning(EXTENSION_NAME, 'Compilation failed; returning error block.')
+        if not do_include then
+          return pandoc.Null()
+        end
         local error_block = create_error_block(compile_err)
         if do_echo then
           local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
@@ -1751,6 +1760,11 @@ local function process_codeblock(el)
     end
 
     result = cell.wrap_crossref(content, opts, REF_TYPE_NAMES)
+  end
+
+  -- Compilation and file-save side effects have run; suppress embedding if include is false.
+  if not do_include then
+    return pandoc.Null()
   end
 
   local output_location = cell.resolve_output_location(opts, EXTENSION_NAME)

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1567,7 +1567,9 @@ local function process_codeblock(el)
   local code = clean_code
   if opts.file then
     code = read_external_file(opts.file)
-    if not code then return el end
+    if not code then
+      return do_include and el or pandoc.Null()
+    end
   end
 
   opts._source = code:sub(1, 200)


### PR DESCRIPTION
`include: false` previously short-circuited before compilation, so the Typst binary was never invoked and no output files were written. This diverged from Quarto semantics, where `include` controls whether output is embedded while `eval` controls whether the code is computed.

`include` is now a post-compute display gate. Blocks with `include: false` compile and write their output files, then embed nothing in the document. Use `eval: false` to skip computation. A failed compilation under `include: false` logs a warning and embeds nothing. The external-file read fallback also returns nothing rather than passing through the raw block when `include: false`.