### PR TITLE
feat: identify failing typst unit in compilation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### New Features
 
 - feat: compilation failure warnings and error blocks now name the failing unit, using its `label` when set, otherwise an auto identifier (`typst-block-N` for blocks, `typst-inline-N` for inline expressions) where `N` is stable per unit.
-  The warning also includes the Typst compiler error, so the failing unit can be located without rendering the document.
+
+### Refactoring
+
+- refactor: drop the redundant `Error running .../typst (error code N)` log line on compilation failure; the Typst CLI already prints its diagnostic to the terminal.
 
 ## 0.13.4 (2026-05-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: compilation failure warnings and error blocks now name the failing unit, using its `label` when set, otherwise an auto identifier (`typst-block-N` for blocks, `typst-inline-N` for inline expressions) where `N` is stable per unit.
+  The warning also includes the Typst compiler error, so the failing unit can be located without rendering the document.
+
 ## 0.13.4 (2026-05-23)
 
 - fix: the default Typst compilation `root` is now the document's own directory instead of the Quarto project directory, so document-relative paths such as `csv("data/energy_cleaned.csv")` resolve against the document.

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -768,10 +768,8 @@ local function compute_cache_stem(source, fmt, dpi, label, inline)
     return 'typst-' .. label .. '-' .. hash
   end
   if inline then
-    inline_counter = inline_counter + 1
     return 'typst-inline-' .. inline_counter .. '-' .. hash
   end
-  block_counter = block_counter + 1
   return 'typst-block-' .. block_counter .. '-' .. hash
 end
 
@@ -1267,12 +1265,20 @@ local function wrap_alignment(block, opts)
   )
 end
 
+--- Build a message identifying the failing unit by its identifier.
+--- @param id string Unit identifier (e.g. fig-foo, typst-block-3, typst-inline-2)
+--- @return string Headline message
+local function compilation_failed_message(id)
+  return "Compilation failed for '" .. id .. "'."
+end
+
 --- Create an error block for failed Typst compilation.
 --- @param err string|nil Error message from the compiler
+--- @param id string Block identifier (e.g. fig-foo, typst-block-3)
 --- @return pandoc.Div Error block
-local function create_error_block(err)
+local function create_error_block(err, id)
   local error_inlines = {
-    pandoc.Strong({ pandoc.Str('[typst-render] Compilation failed for this block.') }),
+    pandoc.Strong({ pandoc.Str('[typst-render] ' .. compilation_failed_message(id)) }),
   }
   if err then
     error_inlines[#error_inlines + 1] = pandoc.LineBreak()
@@ -1521,6 +1527,8 @@ local function process_codeblock(el)
     return nil
   end
 
+  block_counter = block_counter + 1
+
   local block_opts, clean_code, option_lines = cell.parse_options(el.text)
 
   if block_opts['cache-refresh'] ~= nil then
@@ -1540,6 +1548,10 @@ local function process_codeblock(el)
 
   local opts = cell.merge_options(block_opts, global_config, DEFAULTS)
   opts._block_input = block_input_str
+
+  local block_id = (type(opts.label) == 'string' and opts.label ~= '')
+      and opts.label
+      or ('typst-block-' .. block_counter)
 
   -- Resolve per-block colour overrides only. Values inherited from global_config
   -- are already resolved (e.g. 'rgb("#FAF6EE")') and must not be re-wrapped.
@@ -1662,11 +1674,6 @@ local function process_codeblock(el)
   -- Dual-mode rendering for HTML/Reveal.js when both light and dark colours are present
   local dual_mode = quarto.format.is_html_output() and has_dual_mode_colours(opts)
 
-  -- Capture the next block counter value before compilations increment it.
-  -- In dual-mode, compile_to_result is called twice, each incrementing block_counter,
-  -- but we want the first value for the auto-generated output filename.
-  local next_block_counter = block_counter + 1
-
   local result
   if dual_mode then
     local light_opts = resolve_opts_colours(opts, 'light')
@@ -1675,11 +1682,13 @@ local function process_codeblock(el)
     local dark_content, dark_pages, dark_err = compile_to_result(code, dark_opts, img_format)
 
     if not light_content and not dark_content then
-      log.log_warning(EXTENSION_NAME, 'Compilation failed; returning error block.')
+      local err = light_err or dark_err
+      local message = compilation_failed_message(block_id)
+      log.log_warning(EXTENSION_NAME, err and (message .. '\n' .. err) or message)
       if not do_include then
         return pandoc.Null()
       end
-      local error_block = create_error_block(light_err or dark_err)
+      local error_block = create_error_block(err, block_id)
       if do_echo then
         local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
         return pandoc.Blocks({ echo_block, error_block })
@@ -1690,7 +1699,7 @@ local function process_codeblock(el)
     local output_path = resolve_output_path(
       global_config['output-directory'], opts['output-directory'],
       opts['output-filename'], opts.label,
-      'typst-block-' .. next_block_counter, img_format
+      'typst-block-' .. block_counter, img_format
     )
 
     -- Save to output directory and rebuild elements using output paths
@@ -1732,11 +1741,12 @@ local function process_codeblock(el)
 
     if not content then
       if compile_err then
-        log.log_warning(EXTENSION_NAME, 'Compilation failed; returning error block.')
+        local message = compilation_failed_message(block_id)
+        log.log_warning(EXTENSION_NAME, message .. '\n' .. compile_err)
         if not do_include then
           return pandoc.Null()
         end
-        local error_block = create_error_block(compile_err)
+        local error_block = create_error_block(compile_err, block_id)
         if do_echo then
           local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
           return pandoc.Blocks({ echo_block, error_block })
@@ -1750,7 +1760,7 @@ local function process_codeblock(el)
     local output_path = resolve_output_path(
       global_config['output-directory'], opts['output-directory'],
       opts['output-filename'], opts.label,
-      'typst-block-' .. next_block_counter, img_format
+      'typst-block-' .. block_counter, img_format
     )
 
     -- Save to output directory and rebuild element using output paths
@@ -1852,6 +1862,9 @@ local function process_inline_code(el)
     return nil
   end
 
+  inline_counter = inline_counter + 1
+  local inline_id = 'typst-inline-' .. inline_counter
+
   if quarto.format.is_powerpoint_output() then
     if not pptx_inline_warned then
       pptx_inline_warned = true
@@ -1909,8 +1922,8 @@ local function process_inline_code(el)
   local pages, compile_err = compile_typst(full_source, opts, img_format)
 
   if not pages or #pages == 0 then
-    local detail = compile_err and (': ' .. compile_err) or '.'
-    log.log_warning(EXTENSION_NAME, 'Inline Typst compilation failed' .. detail)
+    local message = compilation_failed_message(inline_id)
+    log.log_warning(EXTENSION_NAME, compile_err and (message .. '\n' .. compile_err) or message)
     return el
   end
 

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1003,6 +1003,7 @@ end
 --- @param opts table Merged options
 --- @param img_format string Target image format
 --- @return table|nil List of paths to compiled images, or nil on failure
+--- @return boolean|nil true when compilation failed (Typst prints its own diagnostic)
 local function compile_typst(source, opts, img_format)
   local bin = resolve_typst_bin()
   if not bin then
@@ -1127,14 +1128,9 @@ local function compile_typst(source, opts, img_format)
   args[#args + 1] = '-'
   args[#args + 1] = abs_output
 
-  local ok, result = pcall(pandoc.pipe, bin, args, source)
+  local ok = pcall(pandoc.pipe, bin, args, source)
   if not ok then
-    local err_msg = tostring(result)
-    log.log_error(
-      EXTENSION_NAME,
-      'Typst compilation failed:\n' .. err_msg
-    )
-    return nil, err_msg
+    return nil, true
   end
 
   if is_paged then
@@ -1273,19 +1269,15 @@ local function compilation_failed_message(id)
 end
 
 --- Create an error block for failed Typst compilation.
---- @param err string|nil Error message from the compiler
 --- @param id string Block identifier (e.g. fig-foo, typst-block-3)
 --- @return pandoc.Div Error block
-local function create_error_block(err, id)
-  local error_inlines = {
-    pandoc.Strong({ pandoc.Str('[typst-render] ' .. compilation_failed_message(id)) }),
-  }
-  if err then
-    error_inlines[#error_inlines + 1] = pandoc.LineBreak()
-    error_inlines[#error_inlines + 1] = pandoc.Code(err)
-  end
+local function create_error_block(id)
   return pandoc.Div(
-    pandoc.Blocks({ pandoc.Para(error_inlines) }),
+    pandoc.Blocks({
+      pandoc.Para({
+        pandoc.Strong({ pandoc.Str('[typst-render] ' .. compilation_failed_message(id)) }),
+      }),
+    }),
     pandoc.Attr('', { 'typst-render-error' }, {})
   )
 end
@@ -1296,7 +1288,7 @@ end
 --- @param img_format string Target image format
 --- @return pandoc.Block|nil Result block, or nil on failure
 --- @return table|nil List of selected page paths, or nil on failure
---- @return string|nil Error message on compilation failure
+--- @return boolean|nil true when compilation failed
 local function compile_to_result(code, opts, img_format)
   local full_source = build_typst_source(code, opts)
   local all_pages, compile_err = compile_typst(full_source, opts, img_format)
@@ -1678,17 +1670,15 @@ local function process_codeblock(el)
   if dual_mode then
     local light_opts = resolve_opts_colours(opts, 'light')
     local dark_opts = resolve_opts_colours(opts, 'dark')
-    local light_content, light_pages, light_err = compile_to_result(code, light_opts, img_format)
-    local dark_content, dark_pages, dark_err = compile_to_result(code, dark_opts, img_format)
+    local light_content, light_pages = compile_to_result(code, light_opts, img_format)
+    local dark_content, dark_pages = compile_to_result(code, dark_opts, img_format)
 
     if not light_content and not dark_content then
-      local err = light_err or dark_err
-      local message = compilation_failed_message(block_id)
-      log.log_warning(EXTENSION_NAME, err and (message .. '\n' .. err) or message)
+      log.log_warning(EXTENSION_NAME, compilation_failed_message(block_id))
       if not do_include then
         return pandoc.Null()
       end
-      local error_block = create_error_block(err, block_id)
+      local error_block = create_error_block(block_id)
       if do_echo then
         local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
         return pandoc.Blocks({ echo_block, error_block })
@@ -1741,12 +1731,11 @@ local function process_codeblock(el)
 
     if not content then
       if compile_err then
-        local message = compilation_failed_message(block_id)
-        log.log_warning(EXTENSION_NAME, message .. '\n' .. compile_err)
+        log.log_warning(EXTENSION_NAME, compilation_failed_message(block_id))
         if not do_include then
           return pandoc.Null()
         end
-        local error_block = create_error_block(compile_err, block_id)
+        local error_block = create_error_block(block_id)
         if do_echo then
           local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
           return pandoc.Blocks({ echo_block, error_block })
@@ -1919,11 +1908,10 @@ local function process_inline_code(el)
   end
 
   local full_source = build_typst_source(code, opts)
-  local pages, compile_err = compile_typst(full_source, opts, img_format)
+  local pages = compile_typst(full_source, opts, img_format)
 
   if not pages or #pages == 0 then
-    local message = compilation_failed_message(inline_id)
-    log.log_warning(EXTENSION_NAME, compile_err and (message .. '\n' .. compile_err) or message)
+    log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
     return el
   end
 


### PR DESCRIPTION
Compilation failure warnings and the rendered error block now name the failing unit. A user `label` is used when set; otherwise a stable per-unit identifier is shown: `typst-block-N` for fenced `{typst}` blocks and `typst-inline-N` for inline expressions, where `N` counts each unit in document order. The block and inline counters now increment once per unit at handler entry rather than inside the cache-stem helper, so two failing unlabelled blocks no longer report the same number.

Cross-references are unaffected: only explicit prefixed labels such as `fig-` still turn a block into a float, and the auto identifier is never written to the block label.

On failure the redundant `Error running .../typst (error code N)` line is no longer logged or shown. `pandoc.pipe` does not capture the Typst CLI stderr, while Typst already prints its diagnostic to the terminal, so that wrapper added noise without information. `compile_typst` now returns a boolean failure flag, and warnings and error blocks carry only the failing unit identifier.