### PR TITLE
feat: add code-fold and code-summary for echoed Typst source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: add `code-fold` and `code-summary` options for echoed Typst source.
+  For HTML-based output, `code-fold: true` (or `show` to render expanded) collapses only the echoed code in a `<details>` block, with `code-summary` setting the disclosure text (defaults to `Code`, rendered as Markdown).
+  The rendered output stays outside the fold, and the options are ignored for non-HTML formats.
+
 ## 0.14.0 (2026-05-24)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ This code is shown but not compiled.
 Use `echo: fenced` to display source code wrapped in fenced code block markers (` ```{typst} `), including any comment+pipe options (except `echo` itself).
 This mirrors Quarto's native `echo: fenced` behaviour for computational cells.
 
+For HTML-based output, collapse the echoed source in a `<details>` block with `code-fold`, and set the disclosure text with `code-summary`:
+
+````markdown
+```{typst}
+//| echo: true
+//| code-fold: true
+//| code-summary: "Show the code"
+$ E = m c^2 $
+```
+````
+
+`code-fold` wraps only the echoed source, not the rendered output, and is ignored for non-HTML formats.
+Use `code-fold: show` to render the block expanded by default.
+The summary defaults to `Code` when `code-summary` is unset, and `code-summary` is rendered as Markdown.
+
 ### External File Rendering
 
 Render an external `.typ` file instead of inline code:
@@ -405,6 +420,8 @@ Per-block input override using comma-separated syntax:
 | `output-directory` | string         | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).               |
 | `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted. |
 | `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).                          |
+| `code-fold`       | boolean\|string | `false`   | Collapse the echoed source in a `<details>` block (HTML only). Use `show` to render expanded.  |
+| `code-summary`    | string          | `"Code"`  | Summary text for the `code-fold` `<details>` block (HTML only).                               |
 | `eval`            | boolean         | `true`    | Compile Typst code to image.                                                                  |
 | `include`         | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                                    |
 | `output`          | boolean\|string | `true`    | Show rendered output. Use `asis` for native Typst passthrough.                                |

--- a/_extensions/typst-render/_modules/code-cell.lua
+++ b/_extensions/typst-render/_modules/code-cell.lua
@@ -133,18 +133,48 @@ function M.new(config)
     return merged
   end
 
+  --- Wrap a source listing block in a collapsible `<details>` for HTML output.
+  --- Mimics Quarto's native `code-fold` presentation, reusing its CSS.
+  --- The summary is rendered as Markdown to match Quarto's `code-summary` behaviour.
+  --- Precondition: emits raw HTML, so callers must only invoke this for HTML output.
+  --- @param block pandoc.Block The source listing block to wrap
+  --- @param fold table `{ open = boolean, summary = string|nil }`
+  --- @return pandoc.Blocks The `<details>` open tag, the block, and the close tag
+  function cell.wrap_code_fold(block, fold)
+    local summary = fold.summary
+    if type(summary) ~= 'string' or str.trim(summary) == '' then
+      summary = 'Code'
+    end
+    -- Render the summary as Markdown inlines (no <p> wrapper via Plain).
+    local summary_html = pandoc.write(
+      pandoc.Pandoc(pandoc.Blocks({ pandoc.Plain(quarto.utils.string_to_inlines(summary)) })),
+      'html'
+    ):gsub('%s+$', '')
+    local open_tag = pandoc.RawBlock(
+      'html',
+      '<details' .. (fold.open and ' open' or '') .. ' class="code-fold">\n'
+        .. '<summary>' .. summary_html .. '</summary>'
+    )
+    local close_tag = pandoc.RawBlock('html', '</details>')
+    return pandoc.Blocks({ open_tag, block, close_tag })
+  end
+
   --- Create a source code listing block.
   --- When fenced is true, wraps the code with fenced code block markers and
   --- comment-pipe options to mimic Quarto's `echo: fenced` presentation.
+  --- When fold is given, wraps the listing in a collapsible `<details>`.
   --- @param code string The source code
   --- @param fenced boolean Whether to show fenced code block markers
   --- @param option_lines table|nil Raw comment-pipe lines to include in fenced output
-  --- @return pandoc.CodeBlock A code block for syntax highlighting
-  function cell.create_echo_block(code, fenced, option_lines)
+  --- @param fold table|nil `{ open = boolean, summary = string|nil }` for code-fold
+  --- @return pandoc.Blocks The listing block, optionally wrapped in a `<details>`
+  function cell.create_echo_block(code, fenced, option_lines, fold)
     local meta_patterns = {
       '^%s*' .. escaped_prefix .. '%s*echo:%s*',
       '^%s*' .. escaped_prefix .. '%s*include:%s*',
       '^%s*' .. escaped_prefix .. '%s*output:%s*',
+      '^%s*' .. escaped_prefix .. '%s*code%-fold:%s*',
+      '^%s*' .. escaped_prefix .. '%s*code%-summary:%s*',
     }
     if fenced then
       local lines = { '```{' .. class_name .. '}' }
@@ -164,9 +194,17 @@ function M.new(config)
       end
       lines[#lines + 1] = code
       lines[#lines + 1] = '```'
-      return pandoc.CodeBlock(table.concat(lines, '\n'), pandoc.Attr('', { 'markdown' }, {}))
+      local fenced_block = pandoc.CodeBlock(table.concat(lines, '\n'), pandoc.Attr('', { 'markdown' }, {}))
+      if fold then
+        return cell.wrap_code_fold(fenced_block, fold)
+      end
+      return pandoc.Blocks({ fenced_block })
     end
-    return pandoc.CodeBlock(code, pandoc.Attr('', { class_name }, {}))
+    local plain_block = pandoc.CodeBlock(code, pandoc.Attr('', { class_name }, {}))
+    if fold then
+      return cell.wrap_code_fold(plain_block, fold)
+    end
+    return pandoc.Blocks({ plain_block })
   end
 
   --- Resolve and validate the output-location option.
@@ -194,7 +232,7 @@ function M.new(config)
   end
 
   --- Apply output-location wrapping for Reveal.js presentations.
-  --- @param echo_block pandoc.CodeBlock|nil Echo block (nil when echo is off)
+  --- @param echo_block pandoc.Blocks|nil Echo blocks (nil when echo is off)
   --- @param result pandoc.Block The compiled output block
   --- @param location string The validated output-location value
   --- @return pandoc.Blocks Wrapped output blocks
@@ -206,7 +244,7 @@ function M.new(config)
       local output_classes = location == 'column-fragment'
         and { 'column', 'fragment' }
         or { 'column' }
-      local code_col = pandoc.Div(pandoc.Blocks({ echo_block }), pandoc.Attr('', { 'column' }, {}))
+      local code_col = pandoc.Div(echo_block, pandoc.Attr('', { 'column' }, {}))
       local output_col = pandoc.Div(pandoc.Blocks({ result }), pandoc.Attr('', output_classes, {}))
       local wrapper = pandoc.Div(
         pandoc.Blocks({ code_col, output_col }),
@@ -218,7 +256,10 @@ function M.new(config)
     local wrapper_class = location == 'slide' and 'output-location-slide' or 'fragment'
     local wrapped = pandoc.Div(pandoc.Blocks({ result }), pandoc.Attr('', { wrapper_class }, {}))
     if echo_block then
-      return pandoc.Blocks({ echo_block, wrapped })
+      local blocks = pandoc.Blocks({})
+      blocks:extend(echo_block)
+      blocks:insert(wrapped)
+      return blocks
     end
     return pandoc.Blocks({ wrapped })
   end

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -90,6 +90,15 @@ options:
     enum: [true, false, fenced]
     default: false
     description: "Show Typst source code alongside rendered output. Use 'fenced' to include code block markers."
+  code-fold:
+    type: [boolean, string]
+    enum: [true, false, show]
+    default: false
+    description: "Collapse the echoed source code in a <details> block (HTML output only). Use 'show' to render it expanded."
+  code-summary:
+    type: string
+    default: "Code"
+    description: "Summary text for the code-fold <details> block, rendered as Markdown (HTML output only)."
   eval:
     type: boolean
     default: true
@@ -186,6 +195,13 @@ attributes:
       type: [boolean, string]
       enum: [true, false, fenced]
       description: "Show source code alongside rendered output. Use 'fenced' to include code block markers."
+    code-fold:
+      type: [boolean, string]
+      enum: [true, false, show]
+      description: "Collapse the echoed source code in a <details> block (HTML output only). Use 'show' to render it expanded."
+    code-summary:
+      type: string
+      description: "Summary text for the code-fold <details> block, rendered as Markdown (HTML output only)."
     eval:
       type: boolean
       description: "Compile this block to image."

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -46,6 +46,8 @@ local DEFAULTS = {
   ['output-filename'] = nil,
   input = nil,
   echo = false,
+  ['code-fold'] = false,
+  ['code-summary'] = nil,
   eval = true,
   include = true,
   output = true,
@@ -63,6 +65,7 @@ local DEFAULTS = {
 local KNOWN_KEYS = {
   cap = true,
   alt = true,
+  ['code-summary'] = true,
   _block_input = true,
   _inline = true,
   _alt = true,
@@ -1385,7 +1388,8 @@ local function get_configuration(meta)
     -- so we use a separate key list to ensure 'format' etc. are not missed.
     local config_keys = {
       'format', 'dpi', 'width', 'height', 'margin',
-      'cache', 'cache-refresh', 'echo', 'eval', 'include', 'output', 'output-location', 'classes',
+      'cache', 'cache-refresh', 'echo', 'code-fold', 'code-summary',
+      'eval', 'include', 'output', 'output-location', 'classes',
       'root', 'package-path', 'pages', 'layout-ncol', 'align',
       'output-directory',
     }
@@ -1402,6 +1406,25 @@ local function get_configuration(meta)
               global_config[k] = 'fenced'
             else
               global_config[k] = str == 'true'
+            end
+          end
+        elseif k == 'code-fold' then
+          if type(val) == 'boolean' then
+            global_config[k] = val
+          else
+            local str = pandoc.utils.stringify(val)
+            if str == 'show' then
+              global_config[k] = 'show'
+            elseif str == 'true' then
+              global_config[k] = true
+            elseif str == 'false' then
+              global_config[k] = false
+            else
+              log.log_warning(
+                EXTENSION_NAME,
+                'Invalid code-fold value "' .. str .. '"; expected true, false, or show. Disabling code-fold.'
+              )
+              global_config[k] = false
             end
           end
         elseif k == 'output' then
@@ -1562,6 +1585,20 @@ local function process_codeblock(el)
   local is_fenced = opts.echo == 'fenced'
   local output_mode = cell.resolve_output_mode(opts)
 
+  -- Code-fold wraps only the echoed source in a collapsible <details>, HTML output only.
+  local cf = opts['code-fold']
+  if cf ~= nil and cf ~= false and cf ~= true and cf ~= 'show' then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Invalid code-fold value "' .. tostring(cf) .. '"; expected true, false, or show. Disabling code-fold.'
+    )
+    cf = false
+  end
+  local fold = nil
+  if quarto.format.is_html_output() and (cf == true or cf == 'show') then
+    fold = { open = cf == 'show', summary = opts['code-summary'] }
+  end
+
   -- Handle eval/echo matrix: both false means hidden block
   if not do_eval and not do_echo then
     return pandoc.Null()
@@ -1583,13 +1620,13 @@ local function process_codeblock(el)
     if not do_include then
       return pandoc.Null()
     end
-    return cell.create_echo_block(code, is_fenced, option_lines)
+    return cell.create_echo_block(code, is_fenced, option_lines, fold)
   end
 
   -- Output suppressed: skip compilation, show echo block only
   if output_mode == 'false' then
     if do_echo and do_include then
-      return cell.create_echo_block(code, is_fenced, option_lines)
+      return cell.create_echo_block(code, is_fenced, option_lines, fold)
     end
     return pandoc.Null()
   end
@@ -1635,8 +1672,9 @@ local function process_codeblock(el)
     end
     local result = cell.wrap_crossref(pandoc.RawBlock('typst', scoped_code), opts, REF_TYPE_NAMES)
     if do_echo then
-      local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
-      return pandoc.Blocks({ echo_block, result })
+      local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
+      echo_block:insert(result)
+      return echo_block
     end
     return result
   end
@@ -1680,8 +1718,9 @@ local function process_codeblock(el)
       end
       local error_block = create_error_block(block_id)
       if do_echo then
-        local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
-        return pandoc.Blocks({ echo_block, error_block })
+        local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
+        echo_block:insert(error_block)
+        return echo_block
       end
       return error_block
     end
@@ -1737,8 +1776,9 @@ local function process_codeblock(el)
         end
         local error_block = create_error_block(block_id)
         if do_echo then
-          local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
-          return pandoc.Blocks({ echo_block, error_block })
+          local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
+          echo_block:insert(error_block)
+          return echo_block
         end
         return error_block
       end
@@ -1770,13 +1810,14 @@ local function process_codeblock(el)
 
   local output_location = cell.resolve_output_location(opts, EXTENSION_NAME)
   if output_location then
-    local echo_block = do_echo and cell.create_echo_block(code, is_fenced, option_lines) or nil
+    local echo_block = do_echo and cell.create_echo_block(code, is_fenced, option_lines, fold) or nil
     return cell.apply_output_location(echo_block, result, output_location)
   end
 
   if do_echo then
-    local echo_block = cell.create_echo_block(code, is_fenced, option_lines)
-    return pandoc.Blocks({ echo_block, result })
+    local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
+    echo_block:insert(result)
+    return echo_block
   end
 
   return result

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1438,6 +1438,17 @@ local function get_configuration(meta)
               global_config[k] = str == 'true'
             end
           end
+        elseif k == 'code-summary' then
+          -- Preserve Markdown markup; stringify would flatten it. Per-block
+          -- summaries keep their raw string, so global ones must match.
+          if type(val) == 'string' then
+            global_config[k] = val
+          else
+            global_config[k] = pandoc.write(
+              pandoc.Pandoc(pandoc.Blocks({ pandoc.Plain(val) })),
+              'markdown'
+            ):gsub('%s+$', '')
+          end
         elseif type(default_val) == 'number' then
           local n = tonumber(pandoc.utils.stringify(val))
           if n then

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1441,13 +1441,17 @@ local function get_configuration(meta)
         elseif k == 'code-summary' then
           -- Preserve Markdown markup; stringify would flatten it. Per-block
           -- summaries keep their raw string, so global ones must match.
+          -- Only inline metadata round-trips through the Markdown writer;
+          -- other shapes (bool, list, map, blocks) fall back to stringify.
           if type(val) == 'string' then
             global_config[k] = val
-          else
+          elseif pandoc.utils.type(val) == 'Inlines' then
             global_config[k] = pandoc.write(
               pandoc.Pandoc(pandoc.Blocks({ pandoc.Plain(val) })),
               'markdown'
             ):gsub('%s+$', '')
+          else
+            global_config[k] = pandoc.utils.stringify(val)
           end
         elseif type(default_val) == 'number' then
           local n = tonumber(pandoc.utils.stringify(val))

--- a/example.qmd
+++ b/example.qmd
@@ -244,6 +244,19 @@ This mirrors Quarto's native `echo: fenced` behaviour for computational cells.
 $ integral_0^infinity e^(-x) d x = 1 $
 ```
 
+### Code Fold: Collapsible Source
+
+For HTML-based output, `code-fold: true` collapses the echoed source in a `<details>` block, and `code-summary` sets the disclosure text.
+The rendered output stays outside the fold, and the options are ignored for non-HTML formats.
+
+```{typst}
+//| echo: true
+//| code-fold: true
+//| code-summary: "Show the code"
+#set text(size: 14pt)
+$ e^(i pi) + 1 = 0 $
+```
+
 ### Eval: Source Only (No Compilation)
 
 Display the source code without compiling with `eval: false`:
@@ -689,6 +702,8 @@ extensions:
 | `output-directory` | string         | (none)    | Directory for saving compiled images.                                             |
 | `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`.            |
 | `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).              |
+| `code-fold`       | boolean\|string | `false`   | Collapse echoed source in a `<details>` block (HTML only). Use `show` to expand.  |
+| `code-summary`    | string          | `"Code"`  | Summary text for the `code-fold` `<details>` block (HTML only).                   |
 | `eval`            | boolean         | `true`    | Compile Typst code to image.                                                      |
 | `include`         | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                        |
 | `output`          | boolean\|string | `true`    | Show rendered output. Use `asis` for native Typst passthrough.                    |


### PR DESCRIPTION
Add `code-fold` and `code-summary` options for echoed Typst source in HTML-based output.

`code-fold: true` collapses only the echoed code in a `<details>` block, leaving the rendered output outside the fold. `code-fold: show` renders the block expanded. `code-summary` sets the disclosure text, defaults to `Code`, and is rendered as Markdown for both per-block and document-level values. Both options are ignored for non-HTML formats.

Invalid `code-fold` values emit a warning and disable folding. Whitespace-only, non-string, and non-inline `code-summary` values fall back to `Code` or plain text rather than failing.

For `echo: fenced`, the `code-fold` and `code-summary` comment-pipe lines are stripped from the displayed source, matching how `echo`, `include`, and `output` are handled.