### PR TITLE
feat: support code annotations on echoed Typst source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: support Quarto code annotations on echoed Typst source.
+  With `echo: true`, `// <N>` markers on Typst source lines plus a following numbered list render as linked code annotations, composing with `code-fold`.
+  Other `echo` values (`false`, `fenced`) strip the markers and ignore annotations.
+
 ## 0.15.0 (2026-05-25)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ $ E = m c^2 $
 Use `code-fold: show` to render the block expanded by default.
 The summary defaults to `Code` when `code-summary` is unset, and `code-summary` is rendered as Markdown.
 
+With `echo: true`, Quarto [code annotations](https://quarto.org/docs/authoring/code-annotation.html) work on the Typst source.
+Add `// <N>` markers to the relevant lines, then a numbered list immediately after the block:
+
+````markdown
+```{typst}
+//| echo: true
+#set text(size: 14pt)        // <1>
+$ E = m c^2 $                // <2>
+```
+
+1. Set the text size.
+2. Mass-energy equivalence.
+````
+
+Code annotations are honoured only for `echo: true`; with `echo: false` or `echo: fenced` the `// <N>` markers are stripped and annotations are ignored.
+Annotations compose with `code-fold`.
+
 ### External File Rendering
 
 Render an external `.typ` file instead of inline code:
@@ -419,7 +436,7 @@ Per-block input override using comma-separated syntax:
 | `file`            | string          | (none)    | Path to external `.typ` file to render.                                                       |
 | `output-directory` | string         | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).               |
 | `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted. |
-| `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).                          |
+| `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`). `true` honours code annotations on the source. |
 | `code-fold`       | boolean\|string | `false`   | Collapse the echoed source in a `<details>` block (HTML only). Use `show` to render expanded.  |
 | `code-summary`    | string          | `"Code"`  | Summary text for the `code-fold` `<details>` block (HTML only).                               |
 | `eval`            | boolean         | `true`    | Compile Typst code to image.                                                                  |

--- a/_extensions/typst-render/_modules/code-cell.lua
+++ b/_extensions/typst-render/_modules/code-cell.lua
@@ -32,6 +32,13 @@ function M.new(config)
   local language = config.language
   local comment_prefix = config.comment_prefix
   local escaped_prefix = str.escape_lua_pattern(comment_prefix)
+  --- Line-comment characters used by code annotation markers (`<chars> <N>`).
+  --- Distinct from `comment_prefix` (the comment-pipe prefix, e.g. `//|`).
+  --- Defaults to `comment_prefix` with a trailing `|` removed (e.g. `//`).
+  local comment_chars = config.comment_chars or (comment_prefix:gsub('|$', ''))
+  local escaped_comment_chars = str.escape_lua_pattern(comment_chars)
+  --- Anchored pattern matching a trailing annotation marker, e.g. ` // <1>`.
+  local annotation_pattern = escaped_comment_chars .. '%s*<%d+>%s*$'
   --- Bare language identifier with any single outer `{...}` wrapper stripped
   --- (e.g. `{typst}` -> `typst`). Equals `language` when already brace-free.
   local class_name = language:match('^{(.-)}$') or language
@@ -133,50 +140,59 @@ function M.new(config)
     return merged
   end
 
-  --- Wrap a source listing block in a collapsible `<details>` for HTML output.
-  --- Mimics Quarto's native `code-fold` presentation, reusing its CSS.
-  --- The summary is rendered as Markdown to match Quarto's `code-summary` behaviour.
-  --- Precondition: emits raw HTML, so callers must only invoke this for HTML output.
-  --- @param block pandoc.Block The source listing block to wrap
-  --- @param fold table `{ open = boolean, summary = string|nil }`
-  --- @return pandoc.Blocks The `<details>` open tag, the block, and the close tag
-  function cell.wrap_code_fold(block, fold)
-    local summary = fold.summary
-    if type(summary) ~= 'string' or str.trim(summary) == '' then
-      summary = 'Code'
+  --- Check whether the source carries any code annotation markers.
+  --- A marker is a trailing line comment of the form `<comment_chars> <N>`,
+  --- matching the convention used by Quarto's code-annotations feature.
+  --- @param code string The source code
+  --- @return boolean true if at least one line ends with an annotation marker
+  function cell.has_annotations(code)
+    for line in code:gmatch('[^\r\n]*') do
+      if line:match(annotation_pattern) then
+        return true
+      end
     end
-    -- Render the summary as Markdown inlines (no <p> wrapper via Plain).
-    local summary_html = pandoc.write(
-      pandoc.Pandoc(pandoc.Blocks({ pandoc.Plain(quarto.utils.string_to_inlines(summary)) })),
-      'html'
-    ):gsub('%s+$', '')
-    local open_tag = pandoc.RawBlock(
-      'html',
-      '<details' .. (fold.open and ' open' or '') .. ' class="code-fold">\n'
-        .. '<summary>' .. summary_html .. '</summary>'
-    )
-    local close_tag = pandoc.RawBlock('html', '</details>')
-    return pandoc.Blocks({ open_tag, block, close_tag })
+    return false
+  end
+
+  --- Remove trailing code annotation markers from every line of the source.
+  --- Strips in place so line terminators (including CRLF) are preserved.
+  --- @param code string The source code
+  --- @return string The source with `<comment_chars> <N>` markers stripped
+  function cell.strip_annotations(code)
+    return (code:gsub('[^\r\n]+', function(line)
+      return (line:gsub('%s*' .. annotation_pattern, ''))
+    end))
   end
 
   --- Create a source code listing block.
   --- When fenced is true, wraps the code with fenced code block markers and
   --- comment-pipe options to mimic Quarto's `echo: fenced` presentation.
-  --- When fold is given, wraps the listing in a collapsible `<details>`.
+  --- When fold or annotate is set, emits Quarto's native executable-cell shape
+  --- (a `cell` Div wrapping a `cell-code` CodeBlock, with the rendered result as
+  --- a sibling inside the cell) so that code-fold and code-annotations are handled
+  --- by Quarto's own downstream passes. Otherwise emits a bare CodeBlock followed
+  --- by the result. Annotation markers are stripped unless `annotate` is true.
   --- @param code string The source code
   --- @param fenced boolean Whether to show fenced code block markers
   --- @param option_lines table|nil Raw comment-pipe lines to include in fenced output
   --- @param fold table|nil `{ open = boolean, summary = string|nil }` for code-fold
-  --- @return pandoc.Blocks The listing block, optionally wrapped in a `<details>`
-  function cell.create_echo_block(code, fenced, option_lines, fold)
-    local meta_patterns = {
-      '^%s*' .. escaped_prefix .. '%s*echo:%s*',
-      '^%s*' .. escaped_prefix .. '%s*include:%s*',
-      '^%s*' .. escaped_prefix .. '%s*output:%s*',
-      '^%s*' .. escaped_prefix .. '%s*code%-fold:%s*',
-      '^%s*' .. escaped_prefix .. '%s*code%-summary:%s*',
-    }
+  --- @param result pandoc.Block|nil Rendered output to place after/within the source
+  --- @param annotate boolean|nil Keep annotation markers for Quarto to process
+  --- @return pandoc.Blocks The source listing, optionally wrapped in a `cell` Div
+  function cell.create_echo_block(code, fenced, option_lines, fold, result, annotate)
+    if not annotate then
+      code = cell.strip_annotations(code)
+    end
+
+    local text, classes
     if fenced then
+      local meta_patterns = {
+        '^%s*' .. escaped_prefix .. '%s*echo:%s*',
+        '^%s*' .. escaped_prefix .. '%s*include:%s*',
+        '^%s*' .. escaped_prefix .. '%s*output:%s*',
+        '^%s*' .. escaped_prefix .. '%s*code%-fold:%s*',
+        '^%s*' .. escaped_prefix .. '%s*code%-summary:%s*',
+      }
       local lines = { '```{' .. class_name .. '}' }
       if option_lines then
         for _, line in ipairs(option_lines) do
@@ -194,17 +210,38 @@ function M.new(config)
       end
       lines[#lines + 1] = code
       lines[#lines + 1] = '```'
-      local fenced_block = pandoc.CodeBlock(table.concat(lines, '\n'), pandoc.Attr('', { 'markdown' }, {}))
+      text = table.concat(lines, '\n')
+      classes = { 'markdown' }
+    else
+      text = code
+      classes = { class_name }
+    end
+
+    -- The native cell shape is required for code-fold (attribute-driven, gated
+    -- to HTML by Quarto) and for code-annotations (markers linked downstream).
+    if fold or annotate then
+      classes[#classes + 1] = 'cell-code'
+      local attrs = {}
       if fold then
-        return cell.wrap_code_fold(fenced_block, fold)
+        attrs['code-fold'] = fold.open and 'show' or 'true'
+        local summary = fold.summary
+        if type(summary) == 'string' and str.trim(summary) ~= '' then
+          attrs['code-summary'] = summary
+        end
       end
-      return pandoc.Blocks({ fenced_block })
+      local inner = pandoc.CodeBlock(text, pandoc.Attr('', classes, attrs))
+      local children = pandoc.Blocks({ inner })
+      if result then
+        children:insert(result)
+      end
+      return pandoc.Blocks({ pandoc.Div(children, pandoc.Attr('', { 'cell' }, {})) })
     end
-    local plain_block = pandoc.CodeBlock(code, pandoc.Attr('', { class_name }, {}))
-    if fold then
-      return cell.wrap_code_fold(plain_block, fold)
+
+    local blocks = pandoc.Blocks({ pandoc.CodeBlock(text, pandoc.Attr('', classes, {})) })
+    if result then
+      blocks:insert(result)
     end
-    return pandoc.Blocks({ plain_block })
+    return blocks
   end
 
   --- Resolve and validate the output-location option.

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -89,7 +89,7 @@ options:
     type: [boolean, string]
     enum: [true, false, fenced]
     default: false
-    description: "Show Typst source code alongside rendered output. Use 'fenced' to include code block markers."
+    description: "Show Typst source code alongside rendered output. Use 'fenced' to include code block markers. With 'true', Quarto code annotations on the source (// <N> markers plus a following numbered list) are honoured; other values strip the markers."
   code-fold:
     type: [boolean, string]
     enum: [true, false, show]
@@ -194,7 +194,7 @@ attributes:
     echo:
       type: [boolean, string]
       enum: [true, false, fenced]
-      description: "Show source code alongside rendered output. Use 'fenced' to include code block markers."
+      description: "Show source code alongside rendered output. Use 'fenced' to include code block markers. With 'true', Quarto code annotations on the source (// <N> markers plus a following numbered list) are honoured; other values strip the markers."
     code-fold:
       type: [boolean, string]
       enum: [true, false, show]

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -17,7 +17,7 @@ local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lu
 local paths = require(quarto.utils.resolve_path('_modules/paths.lua'):gsub('%.lua$', ''))
 local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
 local code_cell = require(quarto.utils.resolve_path('_modules/code-cell.lua'):gsub('%.lua$', ''))
-local cell = code_cell.new({ language = '{typst}', comment_prefix = '//|' })
+local cell = code_cell.new({ language = '{typst}', comment_prefix = '//|', comment_chars = '//' })
 
 -- ============================================================================
 -- CONSTANTS
@@ -115,6 +115,11 @@ local global_config = {}
 
 --- Detected brand mode ("light" or "dark")
 local global_brand_mode = 'light'
+
+--- Whether the document disables Quarto code-annotations (set during Meta pass).
+--- When true, annotation markers must be stripped from echoed source because
+--- Quarto's own pass leaves them literal instead of removing them.
+local code_annotations_disabled = false
 
 --- Resolved Typst binary path (cached)
 local typst_bin = nil
@@ -1381,6 +1386,14 @@ local function get_configuration(meta)
   global_brand_mode = (meta['brand-mode'] and pandoc.utils.stringify(meta['brand-mode']) == 'dark')
       and 'dark' or 'light'
 
+  -- Detect whether code-annotations are disabled document-wide. When set to
+  -- false, Quarto's annotation pass is a no-op and leaves `// <N>` markers
+  -- literal, so the filter must strip them from echoed source itself. Set
+  -- unconditionally so the flag never carries over from a previous document.
+  local code_annotations_meta = meta['code-annotations']
+  code_annotations_disabled = code_annotations_meta ~= nil
+    and pandoc.utils.stringify(code_annotations_meta) == 'false'
+
   local ext_config = meta_mod.get_extension_config(meta, EXTENSION_NAME) or meta['typst-render']
 
   if ext_config then
@@ -1600,7 +1613,8 @@ local function process_codeblock(el)
   local is_fenced = opts.echo == 'fenced'
   local output_mode = cell.resolve_output_mode(opts)
 
-  -- Code-fold wraps only the echoed source in a collapsible <details>, HTML output only.
+  -- Code-fold collapses only the echoed source via Quarto's native attribute-driven
+  -- fold (rendered as a <details> for HTML output only).
   local cf = opts['code-fold']
   if cf ~= nil and cf ~= false and cf ~= true and cf ~= 'show' then
     log.log_warning(
@@ -1628,20 +1642,27 @@ local function process_codeblock(el)
     end
   end
 
-  opts._source = code:sub(1, 200)
+  -- _source is the fallback for alt text; annotation markers never belong there.
+  opts._source = cell.strip_annotations(code):sub(1, 200)
+
+  -- Code annotations are honoured only for `echo: true` and when not disabled
+  -- document-wide. Other echo modes strip the markers in create_echo_block.
+  local annotate = opts.echo == true
+    and not code_annotations_disabled
+    and cell.has_annotations(code)
 
   -- Echo-only: show source listing without compilation
   if not do_eval then
     if not do_include then
       return pandoc.Null()
     end
-    return cell.create_echo_block(code, is_fenced, option_lines, fold)
+    return cell.create_echo_block(code, is_fenced, option_lines, fold, nil, annotate)
   end
 
   -- Output suppressed: skip compilation, show echo block only
   if output_mode == 'false' then
     if do_echo and do_include then
-      return cell.create_echo_block(code, is_fenced, option_lines, fold)
+      return cell.create_echo_block(code, is_fenced, option_lines, fold, nil, annotate)
     end
     return pandoc.Null()
   end
@@ -1687,9 +1708,8 @@ local function process_codeblock(el)
     end
     local result = cell.wrap_crossref(pandoc.RawBlock('typst', scoped_code), opts, REF_TYPE_NAMES)
     if do_echo then
-      local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
-      echo_block:insert(result)
-      return echo_block
+      -- Native Typst pass-through does not support annotations; strip markers.
+      return cell.create_echo_block(code, is_fenced, option_lines, fold, result, false)
     end
     return result
   end
@@ -1733,9 +1753,7 @@ local function process_codeblock(el)
       end
       local error_block = create_error_block(block_id)
       if do_echo then
-        local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
-        echo_block:insert(error_block)
-        return echo_block
+        return cell.create_echo_block(code, is_fenced, option_lines, fold, error_block, annotate)
       end
       return error_block
     end
@@ -1791,9 +1809,7 @@ local function process_codeblock(el)
         end
         local error_block = create_error_block(block_id)
         if do_echo then
-          local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
-          echo_block:insert(error_block)
-          return echo_block
+          return cell.create_echo_block(code, is_fenced, option_lines, fold, error_block, annotate)
         end
         return error_block
       end
@@ -1825,14 +1841,15 @@ local function process_codeblock(el)
 
   local output_location = cell.resolve_output_location(opts, EXTENSION_NAME)
   if output_location then
-    local echo_block = do_echo and cell.create_echo_block(code, is_fenced, option_lines, fold) or nil
+    -- Reveal.js output-location layout does not support annotations; strip markers.
+    local echo_block = do_echo
+      and cell.create_echo_block(code, is_fenced, option_lines, fold, nil, false)
+      or nil
     return cell.apply_output_location(echo_block, result, output_location)
   end
 
   if do_echo then
-    local echo_block = cell.create_echo_block(code, is_fenced, option_lines, fold)
-    echo_block:insert(result)
-    return echo_block
+    return cell.create_echo_block(code, is_fenced, option_lines, fold, result, annotate)
   end
 
   return result

--- a/example.qmd
+++ b/example.qmd
@@ -257,6 +257,34 @@ The rendered output stays outside the fold, and the options are ignored for non-
 $ e^(i pi) + 1 = 0 $
 ```
 
+### Code Annotations
+
+With `echo: true`, Quarto code annotations work on the Typst source.
+Add `// <N>` markers to the lines you want to annotate, then a numbered list immediately after the block.
+Other `echo` values (`false`, `fenced`) strip the markers and ignore annotations.
+
+```{typst}
+//| echo: true
+#set text(size: 14pt)        // <1>
+$ sum_(k=1)^n k = (n(n+1))/2 $ // <2>
+```
+
+1. Set the text size.
+2. The sum of the first `n` integers.
+
+Code annotations compose with `code-fold` for HTML-based output.
+
+```{typst}
+//| echo: true
+//| code-fold: true
+//| code-summary: "Annotated source"
+#set page(width: 8cm)        // <1>
+#lorem(10)                   // <2>
+```
+
+1. Fix the page width.
+2. Insert placeholder text.
+
 ### Eval: Source Only (No Compilation)
 
 Display the source code without compiling with `eval: false`:


### PR DESCRIPTION
With `echo: true`, Quarto code annotations now work on the echoed Typst source. Add `// <N>` markers to the source lines and a numbered list immediately after the block, and they render as linked annotations.

The echoed source is emitted in Quarto's native executable-cell shape (a `cell` Div wrapping a `cell-code` code block, with the rendered output as a sibling inside the cell), so Quarto's downstream passes link the annotations and strip the markers. This also lets code annotations compose with `code-fold`, which is now driven by the native `code-fold` and `code-summary` attributes rather than a custom `<details>` wrapper.

Other `echo` values (`false`, `fenced`), native Typst pass-through, and Reveal.js output-location echo strip the markers and ignore annotations. Markers are also stripped when `code-annotations` is disabled document-wide, and never appear in image alt text. CRLF line endings in external files are preserved when markers are stripped.