### PR TITLE
feat: persist compiled Typst source, fix colour double-wrap, clarify PPTX-inline limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: add `output-source` option that writes the compiled Typst source (preamble plus colour bindings plus user code) next to each saved image, using the same stem with a `.typ` extension.
+  Set globally or per block; requires `output-directory` or `output-filename` to take effect.
+  Dual-mode renders write `-light.typ` and `-dark.typ` next to the image variants.
+
+### Bug Fixes
+
+- fix: prevent colour double-wrap when a per-block `background` or `foreground` value is already a Typst-native constructor such as `rgb("#fff")` or `hsl("...")`.
+  The previous logic wrapped any string starting with `rgb(` or `hsl(`, producing invalid `rgb("rgb("#fff")")` literals.
+  CSS functional notation (`rgb(255, 0, 0)`, `hsl(120, 50%, 50%)`) without quoted arguments is still wrapped so Typst's string-form `rgb()` constructor can parse it.
+
+### Documentation
+
+- docs: explain in the PPTX-inline warning why inline Typst is unsupported (Pandoc cannot embed images inside text runs in PPTX slides) while block-level `{typst}` blocks continue to work.
+
 ## 0.16.0 (2026-05-27)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -362,6 +362,16 @@ A per-block `output-filename` starting with `/` overrides the global directory e
 For multi-page output, page numbers are appended before the extension (e.g., `diagram1.png`, `diagram2.png`).
 For dual-mode (light/dark) rendering, `-light` and `-dark` suffixes are appended (e.g., `diagram-light.svg`, `diagram-dark.svg`).
 
+Set `output-source: true` to also persist the compiled Typst source (preamble plus colour bindings plus user code) next to each saved image, using the same stem with a `.typ` extension.
+This makes every persisted image reproducible by recompiling the saved source.
+
+```yaml
+extensions:
+  typst-render:
+    output-directory: /images/typst/
+    output-source: true
+```
+
 ### Foreground and Background Colours
 
 Set text and page fill colours for rendered images.
@@ -436,6 +446,7 @@ Per-block input override using comma-separated syntax:
 | `file`            | string          | (none)    | Path to external `.typ` file to render.                                                       |
 | `output-directory` | string         | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).               |
 | `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted. |
+| `output-source`    | boolean        | `false`   | Also write the compiled Typst source next to each saved image. Requires `output-directory` or `output-filename`. |
 | `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`). `true` honours code annotations on the source. |
 | `code-fold`       | boolean\|string | `false`   | Collapse the echoed source in a `<details>` block (HTML only). Use `show` to render expanded.  |
 | `code-summary`    | string          | `"Code"`  | Summary text for the `code-fold` `<details>` block (HTML only).                               |

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -135,6 +135,10 @@ options:
     description: "Default output directory for saving compiled images. Per-block output-filename paths are resolved relative to this directory."
     completion:
       type: directory
+  output-source:
+    type: boolean
+    default: false
+    description: "Also write the compiled Typst source (preamble + colour bindings + user code) next to each saved image, using the same stem with a .typ extension. Requires output-directory or output-filename to take effect."
 
 # Per-block comment+pipe attributes (//| key: value).
 # These are parsed from the code block text, not from element attributes.
@@ -191,6 +195,9 @@ attributes:
       completion:
         type: file
         extensions: [.png, .svg, .pdf]
+    output-source:
+      type: boolean
+      description: "Also write the compiled Typst source for this block next to its saved image. Requires output-directory or output-filename to take effect."
     echo:
       type: [boolean, string]
       enum: [true, false, fenced]

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -2,7 +2,7 @@
 # Provides configuration validation and IDE support for options
 # and per-block comment+pipe attributes on typst code blocks.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   format:
@@ -10,8 +10,9 @@ options:
     enum: [png, svg, pdf]
     description: "Image output format. Auto-detected from output format if not set."
   dpi:
-    type: number
+    type: integer
     default: 144
+    exclusiveMinimum: 0
     description: "Pixels per inch for PNG output."
   width:
     type: string
@@ -149,7 +150,8 @@ attributes:
       enum: [png, svg, pdf]
       description: "Image output format for this block."
     dpi:
-      type: number
+      type: integer
+      exclusiveMinimum: 0
       description: "Pixels per inch for PNG output."
     width:
       type: string

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -305,12 +305,8 @@ local function css_colour_to_typst(css_colour)
   end
   -- Distinguish bare CSS form (`rgb(255, 0, 0)`) from Typst form (`rgb("...")`).
   -- A Typst-form argument list contains a quote; a bare CSS one never does.
-  local rgb_args = css_colour:match('^rgb%((.+)%)$')
-  if rgb_args and not rgb_args:find('"') and not rgb_args:find("'") then
-    return 'rgb("' .. css_colour .. '")'
-  end
-  local hsl_args = css_colour:match('^hsl%((.+)%)$')
-  if hsl_args and not hsl_args:find('"') and not hsl_args:find("'") then
+  local args = css_colour:match('^rgb%((.+)%)$') or css_colour:match('^hsl%((.+)%)$')
+  if args and not args:find('[\'"]') then
     return 'rgb("' .. css_colour .. '")'
   end
   return css_colour

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -44,6 +44,7 @@ local DEFAULTS = {
   file = nil,
   ['output-directory'] = nil,
   ['output-filename'] = nil,
+  ['output-source'] = false,
   input = nil,
   echo = false,
   ['code-fold'] = false,
@@ -78,6 +79,7 @@ local KNOWN_KEYS = {
   file = true,
   ['output-directory'] = true,
   ['output-filename'] = true,
+  ['output-source'] = true,
   input = true,
   ['output-location'] = true,
   classes = true,
@@ -290,14 +292,25 @@ end
 
 --- Convert a CSS colour string to a Typst colour literal.
 --- Wraps hex values like "#fdfdfd" as rgb("#fdfdfd") for Typst.
---- Passes through values that are already Typst-native (e.g., "blue", "luma(240)").
+--- Wraps bare CSS functional notation (`rgb(255, 0, 0)`, `hsl(...)`) so Typst's
+--- string-form `rgb()` constructor can parse it.
+--- Passes through values that are already Typst-native, including Typst
+--- colour constructors that take a quoted string (`rgb("#fff")`, `hsl("...")`)
+--- or non-functional names (`"blue"`, `"luma(240)"`, `"oklch(...)"`).
 --- @param css_colour string CSS colour string
 --- @return string Typst-compatible colour string
 local function css_colour_to_typst(css_colour)
   if css_colour:match('^#') then
     return 'rgb("' .. css_colour .. '")'
   end
-  if css_colour:match('^rgb%(') or css_colour:match('^hsl%(') then
+  -- Distinguish bare CSS form (`rgb(255, 0, 0)`) from Typst form (`rgb("...")`).
+  -- A Typst-form argument list contains a quote; a bare CSS one never does.
+  local rgb_args = css_colour:match('^rgb%((.+)%)$')
+  if rgb_args and not rgb_args:find('"') and not rgb_args:find("'") then
+    return 'rgb("' .. css_colour .. '")'
+  end
+  local hsl_args = css_colour:match('^hsl%((.+)%)$')
+  if hsl_args and not hsl_args:find('"') and not hsl_args:find("'") then
     return 'rgb("' .. css_colour .. '")'
   end
   return css_colour
@@ -1005,6 +1018,39 @@ local function save_output_files(page_paths, output_path, mode_suffix, img_forma
   return result_paths
 end
 
+--- Write the full compiled Typst source next to a saved output image for
+--- traceability and reproducibility. Uses the image's stem and directory,
+--- replacing the extension with `.typ` (and adding the mode suffix when set).
+--- @param source string Full Typst source actually compiled
+--- @param output_path string Resolved absolute image output path
+--- @param mode_suffix string|nil Optional suffix for dual-mode ("-light", "-dark")
+--- @return boolean True on success
+local function save_source_file(source, output_path, mode_suffix)
+  if not source or source == '' or not output_path then
+    return false
+  end
+  local dir = pandoc.path.directory(output_path)
+  local filename = pandoc.path.filename(output_path)
+  local stem = filename:match('^(.+)%.[^.]+$') or filename
+  if dir and dir ~= '' and dir ~= '.' then
+    local ok, err = pcall(pandoc.system.make_directory, dir, true)
+    if not ok then
+      log.log_warning(EXTENSION_NAME, 'output-source: could not create directory: ' .. tostring(err))
+      return false
+    end
+  end
+  local dst = pandoc.path.join({ dir or '.', stem .. (mode_suffix or '') .. '.typ' })
+  local f, ferr = io.open(dst, 'wb')
+  if not f then
+    log.log_warning(EXTENSION_NAME, 'output-source: could not write to ' .. dst .. ': ' .. tostring(ferr))
+    return false
+  end
+  f:write(source)
+  f:close()
+  log.log_debug(EXTENSION_NAME, 'Saved Typst source to ' .. dst)
+  return true
+end
+
 --- Compile Typst source to an image file (or multiple files for multi-page output).
 --- Uses stdin to pass source code, avoiding temporary .typ files.
 --- @param source string Full Typst source code
@@ -1297,12 +1343,13 @@ end
 --- @return pandoc.Block|nil Result block, or nil on failure
 --- @return table|nil List of selected page paths, or nil on failure
 --- @return boolean|nil true when compilation failed
+--- @return string|nil Full Typst source actually compiled (preamble + colour vars + code)
 local function compile_to_result(code, opts, img_format)
   local full_source = build_typst_source(code, opts)
   local all_pages, compile_err = compile_typst(full_source, opts, img_format)
 
   if not all_pages then
-    return nil, nil, compile_err
+    return nil, nil, compile_err, full_source
   end
 
   local selected_pages
@@ -1321,10 +1368,13 @@ local function compile_to_result(code, opts, img_format)
   end
 
   if #selected_pages == 0 then
-    return nil, nil, nil
+    return nil, nil, nil, full_source
   end
 
-  return wrap_alignment(create_multi_page_element(selected_pages, opts), opts), selected_pages, nil
+  return wrap_alignment(create_multi_page_element(selected_pages, opts), opts),
+    selected_pages,
+    nil,
+    full_source
 end
 
 --- Read an external `.typ` file, resolving relative to the project directory.
@@ -1404,7 +1454,7 @@ local function get_configuration(meta)
       'cache', 'cache-refresh', 'echo', 'code-fold', 'code-summary',
       'eval', 'include', 'output', 'output-location', 'classes',
       'root', 'package-path', 'pages', 'layout-ncol', 'align',
-      'output-directory',
+      'output-directory', 'output-source',
     }
     for _, k in ipairs(config_keys) do
       local default_val = DEFAULTS[k]
@@ -1743,8 +1793,8 @@ local function process_codeblock(el)
   if dual_mode then
     local light_opts = resolve_opts_colours(opts, 'light')
     local dark_opts = resolve_opts_colours(opts, 'dark')
-    local light_content, light_pages = compile_to_result(code, light_opts, img_format)
-    local dark_content, dark_pages = compile_to_result(code, dark_opts, img_format)
+    local light_content, light_pages, _, light_source = compile_to_result(code, light_opts, img_format)
+    local dark_content, dark_pages, _, dark_source = compile_to_result(code, dark_opts, img_format)
 
     if not light_content and not dark_content then
       log.log_warning(EXTENSION_NAME, compilation_failed_message(block_id))
@@ -1766,16 +1816,23 @@ local function process_codeblock(el)
 
     -- Save to output directory and rebuild elements using output paths
     if output_path then
+      local save_source = opts['output-source'] == true
       if light_pages then
         local out_pages = save_output_files(light_pages, output_path, '-light', img_format)
         if out_pages then
           light_content = wrap_alignment(create_multi_page_element(out_pages, light_opts), light_opts)
+        end
+        if save_source then
+          save_source_file(light_source, output_path, '-light')
         end
       end
       if dark_pages then
         local out_pages = save_output_files(dark_pages, output_path, '-dark', img_format)
         if out_pages then
           dark_content = wrap_alignment(create_multi_page_element(out_pages, dark_opts), dark_opts)
+        end
+        if save_source then
+          save_source_file(dark_source, output_path, '-dark')
         end
       end
     end
@@ -1799,7 +1856,7 @@ local function process_codeblock(el)
     local resolved_opts = has_dual_mode_colours(opts)
         and resolve_opts_colours(opts, global_brand_mode)
         or opts
-    local content, selected_pages, compile_err = compile_to_result(code, resolved_opts, img_format)
+    local content, selected_pages, compile_err, full_source = compile_to_result(code, resolved_opts, img_format)
 
     if not content then
       if compile_err then
@@ -1828,6 +1885,9 @@ local function process_codeblock(el)
       local out_pages = save_output_files(selected_pages, output_path, nil, img_format)
       if out_pages then
         content = wrap_alignment(create_multi_page_element(out_pages, resolved_opts), resolved_opts)
+      end
+      if opts['output-source'] == true then
+        save_source_file(full_source, output_path, nil)
       end
     end
 
@@ -1933,7 +1993,10 @@ local function process_inline_code(el)
       log.log_warning(
         EXTENSION_NAME,
         'Inline Typst is not supported for PowerPoint output; '
-        .. 'inline code will be kept as-is.'
+        .. 'inline code will be kept as-is. '
+        .. 'Pandoc cannot embed images inside text runs in PPTX slides, '
+        .. 'so block-level `{typst}` code blocks work normally but '
+        .. 'inline `{typst}` expressions cannot be rendered.'
       )
     end
     return nil

--- a/example.qmd
+++ b/example.qmd
@@ -564,6 +564,24 @@ When a label is present, the filename is derived from the label:
 ]
 ```
 
+### Persist Compiled Source Alongside the Image
+
+Set `output-source: true` to also write the compiled Typst source (preamble plus colour bindings plus user code) next to the saved image, using the same stem with a `.typ` extension.
+This is useful for reproducibility: every persisted image has a recompilable source next to it.
+
+```{typst}
+//| echo: fenced
+//| label: fig-with-source
+//| cap: "Image saved with `.typ` source alongside."
+//| output-directory: _output
+//| output-source: true
+//| format: png
+#set text(size: 14pt)
+#align(center)[
+  Image and source are persisted together.
+]
+```
+
 ::: {.content-hidden when-format="revealjs" when-format="pptx"}
 
 ## Preamble
@@ -729,6 +747,7 @@ extensions:
 | `file`            | string          | (none)    | Path to external `.typ` file to render.                                           |
 | `output-directory` | string         | (none)    | Directory for saving compiled images.                                             |
 | `output-filename`  | string         | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`.            |
+| `output-source`    | boolean        | `false`   | Also write compiled Typst source next to each saved image (same stem, `.typ` extension). |
 | `echo`            | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`).              |
 | `code-fold`       | boolean\|string | `false`   | Collapse echoed source in a `<details>` block (HTML only). Use `show` to expand.  |
 | `code-summary`    | string          | `"Code"`  | Summary text for the `code-fold` `<details>` block (HTML only).                   |


### PR DESCRIPTION
Acts on the priority-1 finding from the review for `quarto-typst-render`.
The colour double-wrap bug is fixed, the PPTX-inline warning now explains the underlying Pandoc limitation, and a new `output-source` option persists the compiled Typst source next to each saved image for reproducibility.

- `typst-render.lua`: `css_colour_to_typst` no longer wraps an already-Typst-native `rgb("...")` or `hsl("...")` literal a second time.
  CSS functional notation (`rgb(255, 0, 0)`) is still wrapped so Typst's string-form `rgb()` constructor can parse it; the prefix-only heuristic was replaced with one that inspects the argument list for a quote.

- `typst-render.lua`: the once-per-document PPTX-inline warning now states that Pandoc cannot embed images inside text runs in PPTX slides, so block-level `{typst}` continues to work but inline `{typst}` cannot.

- `typst-render.lua`, `_schema.yml`, `README.md`, `example.qmd`: add `output-source` (boolean, default `false`).
  When truthy and an output image is being saved to disk, the compiled Typst source (preamble plus colour bindings plus user code) is written next to the image using the same stem with a `.typ` extension.
  Dual-mode renders emit `-light.typ` and `-dark.typ` alongside the image variants.
  Available globally under `extensions.typst-render` and per block via comment+pipe.
