### PR TITLE
feat: add native HTML output and Typst equation rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: add a `html` value for `format` that renders `{typst}` blocks and inline expressions as native HTML for HTML-based output, using Typst 0.15 HTML export.
+  Maths become accessible MathML and prose becomes selectable semantic HTML instead of an image.
+  It requires a Typst >= 0.15 binary via `QUARTO_TYPST` and falls back to SVG otherwise; content that relies on layout must be wrapped in Typst's `html.frame`.
+- feat: add a global `math: typst` option that renders every document equation (`$...$` and `$$...$$`) as Typst math syntax rather than LaTeX.
+  HTML output gets native MathML and Typst output passes the maths through unchanged, while Quarto equation numbering and `@eq-` cross-references keep working.
+  Reference the extension by name without an `at:` stage so its filters run where they are needed.
+
 ## 0.17.0 (2026-05-31)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -25,13 +25,7 @@ filters:
   - typst-render
 ```
 
-For cross-referencing support, use timing control:
-
-```yaml
-filters:
-  - path: typst-render
-    at: pre-quarto
-```
+The extension registers its filters at the pipeline stages it needs (cross-referencing and the `math: typst` equation takeover both depend on this), so reference it by name and do not pin it to a single stage with `at:`.
 
 Then write Typst code blocks in your document:
 
@@ -428,11 +422,54 @@ Per-block input override using comma-separated syntax:
 ```
 ````
 
+### Native HTML Output
+
+For HTML-based output (HTML and Reveal.js), `format: html` renders a `{typst}` block or inline expression to native HTML instead of an image, using Typst's HTML export.
+Maths become accessible MathML, prose becomes selectable semantic HTML, and the result scales with the page.
+
+````markdown
+```{typst}
+//| format: html
+#set text(size: 14pt)
+A *Typst* paragraph with maths $f(x) = sum_(i=0)^n x_i$.
+```
+````
+
+Requirements and caveats:
+
+- Typst HTML export landed in Typst 0.15 and is experimental.
+  Quarto 1.9 bundles Typst 0.14, so set `QUARTO_TYPST` to a Typst >= 0.15 binary, for example `QUARTO_TYPST=/path/to/typst quarto render`.
+- When the binary is older than 0.15, or the output is not HTML-based, the block falls back to an SVG image with a warning.
+- Content that relies on layout (shapes, absolute positioning) does not translate to semantic HTML.
+  Wrap such content in Typst's `html.frame` to embed it as inline SVG.
+
+### Typst Equations
+
+Set the global `math: typst` option to treat every document equation (`$...$` and `$$...$$`) as **Typst** math syntax rather than LaTeX.
+
+```yaml
+extensions:
+  typst-render:
+    math: typst
+```
+
+```markdown
+Inline $f(x) = sum_(i=0)^n x_i$ and a display equation:
+
+$$ x^2 + y^2 = z^2 $$ {#eq-pythagoras}
+
+See @eq-pythagoras.
+```
+
+- For HTML output the equations become native MathML (same Typst >= 0.15 requirement as above; otherwise Quarto's default math renderer is kept).
+- For Typst output the equations pass through unchanged, so author-written Typst syntax is not reinterpreted as LaTeX.
+- Quarto equation numbering and `@eq-` cross-references keep working.
+
 ### Options
 
 | Option             | Type            | Default   | Description                                                                                                         |
 | ------------------ | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------- |
-| `format`           | string          | (auto)    | Image format: `png`, `svg`, `pdf`.                                                                                  |
+| `format`           | string          | (auto)    | Output format: `png`, `svg`, `pdf`, or `html`. See [Native HTML Output](#native-html-output).                       |
 | `dpi`              | number          | `144`     | Pixels per inch (PNG only).                                                                                         |
 | `width`            | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                                                     |
 | `height`           | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                                                    |
@@ -471,6 +508,7 @@ These options can only be set in the document YAML and cannot be overridden per 
 | `root`         | string        | (document directory) | Root directory for Typst compilation. Relative paths resolve against the document directory; a leading `/` means the project root. |
 | `font-path`    | string\|array | (none)               | Path or list of paths to directories containing additional fonts.                                                                  |
 | `package-path` | string        | (none)               | Path to a directory containing Typst packages (offline/reproducible).                                                              |
+| `math`         | string        | (none)               | Set to `typst` to render every document equation as Typst math. See [Typst Equations](#typst-equations).                           |
 
 ### Per-Block Cross-Referencing Options
 
@@ -491,6 +529,8 @@ These options can only be set in the document YAML and cannot be overridden per 
 | Typst           | `png`                |
 | DOCX / PPTX     | `png`                |
 | Other           | `png`                |
+
+`html` is never auto-selected; opt in with `format: html` (see [Native HTML Output](#native-html-output)).
 
 ### Echo/Eval Behaviour
 

--- a/_extensions/typst-render/_extension.yml
+++ b/_extensions/typst-render/_extension.yml
@@ -6,3 +6,5 @@ contributes:
   filters:
     - at: pre-quarto
       path: typst-render.lua
+    - at: post-quarto
+      path: typst-math.lua

--- a/_extensions/typst-render/_modules/typst-cli.lua
+++ b/_extensions/typst-render/_modules/typst-cli.lua
@@ -117,7 +117,7 @@ function M.read_file(path)
 end
 
 --- Inject the MathML/layout CSS that Typst HTML export emits in its document
---- head, at most once per filter pass (this module is loaded per Lua state).
+--- head, at most once per document.
 --- @param html string Full Typst HTML document
 local head_injected = false
 function M.inject_head_style_once(html)
@@ -129,6 +129,13 @@ function M.inject_head_style_once(html)
     quarto.doc.include_text('in-header', '<style>\n' .. style .. '\n</style>')
     head_injected = true
   end
+end
+
+--- Clear the head-injection guard. Quarto may reuse a single Lua state across
+--- documents in a batch render, so each document's Meta pass must reset this
+--- before its first block/equation injects the head CSS.
+function M.reset_head_injection()
+  head_injected = false
 end
 
 --- Per-document cache subdirectory derived from the input file stem.

--- a/_extensions/typst-render/_modules/typst-cli.lua
+++ b/_extensions/typst-render/_modules/typst-cli.lua
@@ -1,0 +1,146 @@
+--- MC Typst CLI - Typst binary discovery, version detection, and HTML extraction
+--- @module typst-cli
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+--- @brief Shared Typst helpers used by both the typst-render and typst-math filters.
+
+local M = {}
+
+--- Resolved Typst binary path (cached across calls).
+local bin_cache = nil
+local bin_checked = false
+
+--- Parsed Typst version table { major, minor } (cached); false when unavailable.
+local version_cache = nil
+
+--- Resolve the Typst binary path via Quarto.
+--- Honours the QUARTO_TYPST environment variable (Quarto resolves it before the
+--- bundled binary), so pointing QUARTO_TYPST at a newer Typst is reflected here.
+--- @return string|nil Path to the Typst binary, or nil if not found
+function M.resolve_bin()
+  if bin_checked then
+    return bin_cache
+  end
+  bin_checked = true
+  local path = quarto.paths.typst()
+  if path and path ~= '' then
+    bin_cache = path
+  end
+  return bin_cache
+end
+
+--- Detect the version of the resolved Typst binary by invoking `typst --version`.
+--- @param bin string Path to the Typst binary
+--- @return table|nil { major = number, minor = number }, or nil on failure
+function M.get_version(bin)
+  if version_cache ~= nil then
+    return version_cache or nil
+  end
+  local ok, out = pcall(pandoc.pipe, bin, { '--version' }, '')
+  if ok and type(out) == 'string' then
+    local major, minor = out:match('(%d+)%.(%d+)')
+    if major and minor then
+      version_cache = { major = tonumber(major), minor = tonumber(minor) }
+      return version_cache
+    end
+  end
+  version_cache = false
+  return nil
+end
+
+--- Whether the resolved Typst binary supports HTML export (Typst >= 0.15).
+--- @param bin string Path to the Typst binary
+--- @return boolean
+function M.supports_html(bin)
+  local v = M.get_version(bin)
+  if not v then
+    return false
+  end
+  return v.major > 0 or v.minor >= 15
+end
+
+--- Extract the inner HTML of the `<body>` element from a full Typst HTML document.
+--- @param html string Full HTML document
+--- @return string Body inner HTML, or the whole input when no body is found
+function M.extract_body(html)
+  local body = html:match('<body[^>]*>(.*)</body>')
+  if body then
+    return body
+  end
+  return html
+end
+
+--- Extract the concatenated contents of `<style>` blocks found in the document head.
+--- Typst HTML export emits MathML layout CSS in the head; it must be injected once
+--- into the host document for correct rendering.
+--- @param html string Full HTML document
+--- @return string|nil Style contents, or nil when none are present
+function M.extract_head_style(html)
+  local head = html:match('<head[^>]*>(.-)</head>')
+  if not head then
+    return nil
+  end
+  local styles = {}
+  for style in head:gmatch('<style[^>]*>(.-)</style>') do
+    styles[#styles + 1] = style
+  end
+  if #styles == 0 then
+    return nil
+  end
+  return table.concat(styles, '\n')
+end
+
+--- Strip a single outer `<p>...</p>` wrapper, used to inline body content.
+--- @param s string HTML fragment
+--- @return string Fragment without an outer paragraph wrapper
+function M.strip_paragraph(s)
+  local inner = s:match('^%s*<p[^>]*>(.*)</p>%s*$')
+  if inner then
+    return inner
+  end
+  return s
+end
+
+--- Read a file's full contents.
+--- @param path string File path
+--- @return string|nil File contents, or nil when the file cannot be opened
+function M.read_file(path)
+  local f = io.open(path, 'r')
+  if not f then
+    return nil
+  end
+  local content = f:read('*a')
+  f:close()
+  return content
+end
+
+--- Inject the MathML/layout CSS that Typst HTML export emits in its document
+--- head, at most once per filter pass (this module is loaded per Lua state).
+--- @param html string Full Typst HTML document
+local head_injected = false
+function M.inject_head_style_once(html)
+  if head_injected then
+    return
+  end
+  local style = M.extract_head_style(html)
+  if style and style ~= '' then
+    quarto.doc.include_text('in-header', '<style>\n' .. style .. '\n</style>')
+    head_injected = true
+  end
+end
+
+--- Per-document cache subdirectory derived from the input file stem.
+--- @return string Cache subdirectory (e.g. ".quarto/typst-render/index")
+function M.doc_cache_subdir()
+  local doc_stem = 'default'
+  local input_file = quarto.doc.input_file
+  if input_file and input_file ~= '' then
+    local input_name = pandoc.path.filename(input_file)
+    doc_stem = input_name:match('^(.+)%.[^.]+$') or input_name
+  end
+  return pandoc.path.join({ '.quarto/typst-render', doc_stem })
+end
+
+return M

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -7,8 +7,12 @@ $schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.j
 options:
   format:
     type: string
-    enum: [png, svg, pdf]
-    description: "Image output format. Auto-detected from output format if not set."
+    enum: [png, svg, pdf, html]
+    description: "Output format. Auto-detected from output format if not set. Use 'html' for native HTML (semantic markup with MathML maths) in HTML-based output; it requires Typst >= 0.15 (set QUARTO_TYPST to a Typst >= 0.15 binary) and falls back to SVG otherwise."
+  math:
+    type: string
+    enum: [typst]
+    description: "Global only. Set to 'typst' to render every document equation ($...$ and $$...$$) as Typst math syntax (not LaTeX). For HTML output the maths become native MathML (requires Typst >= 0.15 via QUARTO_TYPST, else Quarto's renderer is kept); for Typst output the maths pass through unchanged. Quarto equation numbering and cross-references keep working."
   dpi:
     type: integer
     default: 144
@@ -147,8 +151,8 @@ attributes:
   typst:
     format:
       type: string
-      enum: [png, svg, pdf]
-      description: "Image output format for this block."
+      enum: [png, svg, pdf, html]
+      description: "Output format for this block. Use 'html' for native HTML (semantic markup with MathML maths) in HTML-based output; requires Typst >= 0.15 (set QUARTO_TYPST), falls back to SVG otherwise."
     dpi:
       type: integer
       exclusiveMinimum: 0

--- a/_extensions/typst-render/typst-math.lua
+++ b/_extensions/typst-render/typst-math.lua
@@ -185,6 +185,16 @@ end
 --- @param meta pandoc.Meta
 --- @return pandoc.Meta
 local function configure(meta)
+  -- Reset per-document state: Quarto may reuse the Lua state across documents in
+  -- a batch render, so a document that does not opt in must not inherit a prior
+  -- document's mode, fonts, or cached equations.
+  html_mode = false
+  typst_mode = false
+  font_paths = nil
+  package_path = nil
+  css_injected = false
+  html_cache = {}
+  typst_cli.reset_head_injection()
   cache_subdir = typst_cli.doc_cache_subdir()
 
   local ext_config = meta_mod.get_extension_config(meta, EXTENSION_NAME) or meta['typst-render']

--- a/_extensions/typst-render/typst-math.lua
+++ b/_extensions/typst-render/typst-math.lua
@@ -1,0 +1,198 @@
+--- Typst Math - Filter (post-quarto)
+--- @module "typst-math"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @brief Renders document equations as Typst math for HTML and Typst output.
+--- @description When `math: typst` is set, treats the contents of every `$...$`
+---   and `$$...$$` as Typst math syntax (not LaTeX). For Typst output it emits the
+---   math verbatim so Pandoc's writer does not reinterpret it as LaTeX; for HTML
+---   output (Typst >= 0.15) it compiles the math to native MathML. Runs at
+---   post-quarto so Quarto's equation numbering and `@eq-` cross-references, which
+---   wrap equations in a labelled span, are already in place and left untouched.
+
+local EXTENSION_NAME = 'typst-render'
+
+local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
+local typst_cli = require(quarto.utils.resolve_path('_modules/typst-cli.lua'):gsub('%.lua$', ''))
+
+--- Module state
+local cache_subdir = nil
+local html_mode = false
+local typst_mode = false
+local css_injected = false
+
+--- In-render cache of compiled math bodies, keyed by Typst source.
+local html_cache = {}
+
+--- Resolve the Typst binary path.
+--- @return string|nil
+local function resolve_bin()
+  local bin = typst_cli.resolve_bin()
+  if not bin then
+    log.log_error(EXTENSION_NAME, 'Typst binary not found. Ensure Quarto >= 1.6 is installed.')
+  end
+  return bin
+end
+
+--- Ensure the per-document cache directory exists.
+--- @return string|nil Absolute path to the cache directory, or nil on failure
+local function ensure_cache_dir()
+  if not cache_subdir then
+    return nil
+  end
+  local abs_path = pandoc.path.join({ quarto.project.directory, cache_subdir })
+  local ok = pcall(pandoc.system.make_directory, abs_path, true)
+  if not ok then
+    return nil
+  end
+  return abs_path
+end
+
+--- Inject the equation-numbering layout CSS, once per render.
+local function inject_number_css_once()
+  if css_injected then
+    return
+  end
+  quarto.doc.include_text(
+    'in-header',
+    '<style>\n'
+    .. '.typst-eq{display:flex;align-items:center;justify-content:center;position:relative;}\n'
+    .. '.typst-eq>.typst-eq-number{position:absolute;right:0;}\n'
+    -- Inside cross-reference hover previews (tippy popups) the flex/absolute rules
+    -- squash the cloned equation; render it in normal flow and drop the number
+    -- (the number is the reference itself, so it is redundant in the preview).
+    .. '.tippy-content .typst-eq{display:block;}\n'
+    .. '.tippy-content .typst-eq>.typst-eq-number{display:none;}\n'
+    .. '</style>'
+  )
+  css_injected = true
+end
+
+--- Compile a Typst math expression to HTML and return its `<body>` content.
+--- Memoised in-render and cached on disk, both keyed by the Typst source.
+--- @param source string Full Typst source (e.g. "$ x^2 $")
+--- @return string|nil Body inner HTML, or nil on failure
+local function compile_math_html(source)
+  local cached_body = html_cache[source]
+  if cached_body ~= nil then
+    return cached_body or nil
+  end
+
+  local bin = resolve_bin()
+  if not bin then
+    return nil
+  end
+  local abs_cache = ensure_cache_dir()
+  if not abs_cache then
+    return nil
+  end
+  local hash = pandoc.utils.sha1(source):sub(1, 12)
+  local abs_output = pandoc.path.join({ abs_cache, 'typst-math-' .. hash .. '.html' })
+
+  local html = typst_cli.read_file(abs_output)
+  if not html then
+    local root = quarto.project.directory or '.'
+    local args = { 'compile', '--format', 'html', '--features', 'html', '--root', root, '-', abs_output }
+    local ok = pcall(pandoc.pipe, bin, args, source)
+    if not ok then
+      return nil
+    end
+    html = typst_cli.read_file(abs_output)
+    if not html then
+      log.log_error(EXTENSION_NAME, 'Compiled math HTML not found: ' .. abs_output)
+      return nil
+    end
+  end
+  typst_cli.inject_head_style_once(html)
+  local body = typst_cli.extract_body(html)
+  html_cache[source] = body or false
+  return body
+end
+
+--- Replace a Math element rendered for HTML output with native MathML.
+--- @param m pandoc.Math
+--- @return pandoc.Inline|nil
+local function render_html_math(m)
+  if m.mathtype == 'InlineMath' then
+    local body = compile_math_html('$' .. m.text .. '$')
+    if not body then
+      return nil
+    end
+    return pandoc.RawInline('html', typst_cli.strip_paragraph(body))
+  end
+
+  -- Display math: strip the equation number Quarto appended. The form depends on
+  -- the html-math-method: \tag{N} for mathjax/katex, \qquad(N) for mathml/plain.
+  local number = m.text:match('\\tag%{(%d+)%}') or m.text:match('\\qquad%((%d+)%)')
+  local cleaned = m.text:gsub('\\tag%{%d+%}', ''):gsub('\\qquad%((%d+)%)', '')
+  local body = compile_math_html('$ ' .. cleaned .. ' $')
+  if not body then
+    return nil
+  end
+  if number then
+    inject_number_css_once()
+    return pandoc.RawInline(
+      'html',
+      '<span class="typst-eq">' .. body
+      .. '<span class="typst-eq-number">(' .. number .. ')</span></span>'
+    )
+  end
+  return pandoc.RawInline('html', body)
+end
+
+--- Process a Math element.
+--- @param m pandoc.Math
+--- @return pandoc.Inline|nil
+local function process_math(m)
+  if typst_mode then
+    -- Emit Typst math verbatim so Pandoc's writer does not treat it as LaTeX.
+    -- Display math sits inside Quarto's #math.equation([...]) wrapper, where a
+    -- $...$ equation is the valid markup-mode form.
+    return pandoc.RawInline('typst', '$' .. m.text .. '$')
+  end
+
+  if html_mode then
+    return render_html_math(m)
+  end
+
+  return nil
+end
+
+--- Read configuration and decide whether the takeover is active.
+--- @param meta pandoc.Meta
+--- @return pandoc.Meta
+local function configure(meta)
+  cache_subdir = typst_cli.doc_cache_subdir()
+
+  local ext_config = meta_mod.get_extension_config(meta, EXTENSION_NAME) or meta['typst-render']
+  local math_opt = ext_config and ext_config['math'] and pandoc.utils.stringify(ext_config['math'])
+  if math_opt ~= 'typst' then
+    return meta
+  end
+
+  -- Only HTML output that can run Typst HTML export gets the MathML takeover;
+  -- on an older Typst, leave Quarto's renderer in place. Typst output always
+  -- passes through (no Typst CLI needed).
+  if quarto.format.is_typst_output() then
+    typst_mode = true
+  elseif quarto.format.is_html_output() then
+    if typst_cli.supports_html(typst_cli.resolve_bin()) then
+      html_mode = true
+    else
+      log.log_warning(
+        EXTENSION_NAME,
+        'math: typst requires Typst >= 0.15 for HTML output. Set QUARTO_TYPST to a Typst >= 0.15 '
+        .. 'binary to enable native MathML; leaving Quarto math rendering in place.'
+      )
+    end
+  end
+
+  return meta
+end
+
+return {
+  { Meta = configure },
+  { Math = process_math },
+}

--- a/_extensions/typst-render/typst-math.lua
+++ b/_extensions/typst-render/typst-math.lua
@@ -15,6 +15,7 @@ local EXTENSION_NAME = 'typst-render'
 
 local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
 local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
+local paths = require(quarto.utils.resolve_path('_modules/paths.lua'):gsub('%.lua$', ''))
 local typst_cli = require(quarto.utils.resolve_path('_modules/typst-cli.lua'):gsub('%.lua$', ''))
 
 --- Module state
@@ -22,6 +23,11 @@ local cache_subdir = nil
 local html_mode = false
 local typst_mode = false
 local css_injected = false
+
+--- Font and package directories, read from global config so equations compile
+--- with the same resources as `format: html` blocks.
+local font_paths = nil
+local package_path = nil
 
 --- In-render cache of compiled math bodies, keyed by Typst source.
 local html_cache = {}
@@ -94,7 +100,19 @@ local function compile_math_html(source)
   local html = typst_cli.read_file(abs_output)
   if not html then
     local root = quarto.project.directory or '.'
-    local args = { 'compile', '--format', 'html', '--features', 'html', '--root', root, '-', abs_output }
+    local args = { 'compile', '--format', 'html', '--features', 'html', '--root', root }
+    if font_paths then
+      for _, p in ipairs(font_paths) do
+        args[#args + 1] = '--font-path'
+        args[#args + 1] = paths.resolve_project_path(p)
+      end
+    end
+    if package_path then
+      args[#args + 1] = '--package-path'
+      args[#args + 1] = paths.resolve_project_path(package_path)
+    end
+    args[#args + 1] = '-'
+    args[#args + 1] = abs_output
     local ok = pcall(pandoc.pipe, bin, args, source)
     if not ok then
       return nil
@@ -125,6 +143,9 @@ local function render_html_math(m)
 
   -- Display math: strip the equation number Quarto appended. The form depends on
   -- the html-math-method: \tag{N} for mathjax/katex, \qquad(N) for mathml/plain.
+  -- All numbers are stripped so none leak into the Typst source; a single-number
+  -- span is rendered (a multi-line aligned block with several numbers shows only
+  -- the first, which the single-equation common case never hits).
   local number = m.text:match('\\tag%{(%d+)%}') or m.text:match('\\qquad%((%d+)%)')
   local cleaned = m.text:gsub('\\tag%{%d+%}', ''):gsub('\\qquad%((%d+)%)', '')
   local body = compile_math_html('$ ' .. cleaned .. ' $')
@@ -170,6 +191,24 @@ local function configure(meta)
   local math_opt = ext_config and ext_config['math'] and pandoc.utils.stringify(ext_config['math'])
   if math_opt ~= 'typst' then
     return meta
+  end
+
+  -- Resolve the same font/package directories the render filter uses, so equations
+  -- compiled here match `format: html` blocks. (root and input are not applied:
+  -- self-contained equations do not reference files or sys.inputs.)
+  if ext_config['font-path'] ~= nil then
+    local raw = ext_config['font-path']
+    if pandoc.utils.type(raw) == 'List' then
+      font_paths = {}
+      for _, v in ipairs(raw) do
+        font_paths[#font_paths + 1] = pandoc.utils.stringify(v)
+      end
+    else
+      font_paths = { pandoc.utils.stringify(raw) }
+    end
+  end
+  if ext_config['package-path'] ~= nil then
+    package_path = pandoc.utils.stringify(ext_config['package-path'])
   end
 
   -- Only HTML output that can run Typst HTML export gets the MathML takeover;

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -392,17 +392,10 @@ end
 -- ============================================================================
 
 --- Read the entire contents of a file.
+--- Read a file's full contents (shared with the math filter).
 --- @param path string The file path to read
 --- @return string|nil File contents, or nil if the file cannot be opened
-local function read_file(path)
-  local f = io.open(path, 'r')
-  if not f then
-    return nil
-  end
-  local content = f:read('*a')
-  f:close()
-  return content
-end
+local read_file = typst_cli.read_file
 
 --- Serialise all merged options as a sorted, deterministic string for cache hashing.
 --- Handles string, number, boolean, and nested table values.
@@ -821,7 +814,11 @@ end
 local function compute_cache_stem(source, fmt, dpi, label, inline)
   local hash = pandoc.utils.sha1(source .. '|' .. fmt .. '|' .. dpi):sub(1, 8)
   if type(label) == 'string' and label ~= '' then
-    return 'typst-' .. label .. '-' .. hash
+    -- Sanitise the label before using it as a filename component so an unusual
+    -- label cannot escape the cache directory; valid cross-ref labels are
+    -- unaffected (only [%w-_] survive).
+    local safe_label = label:gsub('[^%w%-_]', '_')
+    return 'typst-' .. safe_label .. '-' .. hash
   end
   if inline then
     return 'typst-inline-' .. inline_counter .. '-' .. hash

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -76,6 +76,7 @@ local KNOWN_KEYS = {
   root = true,
   ['font-path'] = true,
   ['package-path'] = true,
+  math = true,
   format = true,
   foreground = true,
   file = true,

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -1539,6 +1539,9 @@ end
 local function get_configuration(meta)
   register_custom_crossref_types(meta)
   read_file_cache = {}
+  -- Quarto may reuse the Lua state across documents; re-inject the Typst head
+  -- CSS for each document that produces native HTML output.
+  typst_cli.reset_head_injection()
 
   -- Build per-document cache subdirectory from the input file stem
   cache_subdir = typst_cli.doc_cache_subdir()
@@ -2221,7 +2224,11 @@ local function cleanup_cache(doc) -- luacheck: ignore 212
 
   local removed = 0
   for _, filename in ipairs(entries) do
-    if filename:match('^typst%-') and not used_cache_files[filename] then
+    -- Skip `typst-math-*` files: they are owned by the typst-math filter and not
+    -- tracked here, so this cleanup must not treat them as stale.
+    if filename:match('^typst%-')
+        and not filename:match('^typst%-math%-')
+        and not used_cache_files[filename] then
       local ext = filename:match('%.(%w+)$')
       if ext and used_cache_formats[ext] then
         local filepath = pandoc.path.join({ abs_cache, filename })

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -16,6 +16,7 @@ local str = require(quarto.utils.resolve_path('_modules/string.lua'):gsub('%.lua
 local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
 local paths = require(quarto.utils.resolve_path('_modules/paths.lua'):gsub('%.lua$', ''))
 local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
+local typst_cli = require(quarto.utils.resolve_path('_modules/typst-cli.lua'):gsub('%.lua$', ''))
 local code_cell = require(quarto.utils.resolve_path('_modules/code-cell.lua'):gsub('%.lua$', ''))
 local cell = code_cell.new({ language = '{typst}', comment_prefix = '//|', comment_chars = '//' })
 
@@ -23,8 +24,9 @@ local cell = code_cell.new({ language = '{typst}', comment_prefix = '//|', comme
 -- CONSTANTS
 -- ============================================================================
 
---- Valid image format set for O(1) lookup
-local VALID_FORMAT_SET = { png = true, svg = true, pdf = true }
+--- Valid output format set for O(1) lookup. `html` is a native (non-image)
+--- target available with Typst >= 0.15; the others compile to image files.
+local VALID_FORMAT_SET = { png = true, svg = true, pdf = true, html = true }
 
 --- Valid alignment values
 local VALID_ALIGN_SET = { left = true, center = true, right = true, default = true }
@@ -101,9 +103,6 @@ local function is_known_key(key)
   end
   return key:match('^%a+%-cap$') ~= nil or key:match('^%a+%-alt$') ~= nil
 end
-
---- Cache base directory within the .quarto scratch directory
-local CACHE_BASE = '.quarto/typst-render'
 
 --- Per-document cache subdirectory (set during Meta pass)
 local cache_subdir = nil
@@ -498,19 +497,55 @@ local function resolve_typst_bin()
   end
   typst_checked = true
 
-  local path = quarto.paths.typst()
-  if path and path ~= '' then
-    typst_bin = path
-    return typst_bin
+  typst_bin = typst_cli.resolve_bin()
+  if not typst_bin then
+    log.log_error(EXTENSION_NAME, 'Typst binary not found. Ensure Quarto >= 1.6 is installed.')
   end
+  return typst_bin
+end
 
-  log.log_error(EXTENSION_NAME, 'Typst binary not found. Ensure Quarto >= 1.6 is installed.')
-  return nil
+--- Whether the resolved Typst binary supports HTML export (Typst >= 0.15).
+--- @return boolean
+local function typst_supports_html()
+  local bin = resolve_typst_bin()
+  if not bin then
+    return false
+  end
+  return typst_cli.supports_html(bin)
+end
+
+-- Forward declaration; defined after get_image_format_for_output.
+local get_image_format_for_output
+
+--- Resolve the requested format, downgrading `html` to an image format when it
+--- cannot be honoured (non-HTML output, or Typst < 0.15), with a warning.
+--- @param img_format string Requested format
+--- @return string Effective format
+local function resolve_html_format(img_format)
+  if img_format ~= 'html' then
+    return img_format
+  end
+  if not quarto.format.is_html_output() then
+    log.log_warning(
+      EXTENSION_NAME,
+      'format "html" is only available for HTML-based output; falling back to an image.'
+    )
+    return get_image_format_for_output()
+  end
+  if not typst_supports_html() then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Native HTML output requires Typst >= 0.15. Set QUARTO_TYPST to a Typst >= 0.15 '
+      .. 'binary to enable it; falling back to SVG.'
+    )
+    return 'svg'
+  end
+  return 'html'
 end
 
 --- Determine the best image format for the current output.
 --- @return string Image format: "svg", "pdf", or "png"
-local function get_image_format_for_output()
+function get_image_format_for_output()
   if quarto.format.is_html_output() then
     return 'svg'
   elseif quarto.format.is_latex_output() then
@@ -749,18 +784,22 @@ local function has_custom_block_options(opts)
       or opts.margin ~= DEFAULTS.margin
 end
 
---- Build the full Typst source with page template.
+--- Build the full Typst source.
 --- @param code string User Typst code
 --- @param opts table Merged options
+--- @param include_page boolean|nil Emit `#set page(...)` (default true). HTML
+---   export ignores page geometry, so callers targeting HTML pass false.
 --- @return string Complete Typst source
-local function build_typst_source(code, opts)
+local function build_typst_source(code, opts, include_page)
   local parts = {}
   inject_colour_vars(parts, opts)
   local define_preamble = build_define_preamble()
   if define_preamble then
     parts[#parts + 1] = define_preamble
   end
-  parts[#parts + 1] = build_page_directive(opts)
+  if include_page ~= false then
+    parts[#parts + 1] = build_page_directive(opts)
+  end
   if opts.foreground then
     parts[#parts + 1] = '#set text(fill: ' .. opts.foreground .. ')'
   end
@@ -1047,6 +1086,53 @@ local function save_source_file(source, output_path, mode_suffix)
   return true
 end
 
+--- Build the cache-key material shared by every compile path.
+--- @param source string Full Typst source
+--- @param opts table Merged options
+--- @param resolved_root string Resolved compilation root
+--- @param merged_input table Merged input variables
+--- @return string Hash material (source + inputs + options + imported file contents)
+local function build_hash_source(source, opts, resolved_root, merged_input)
+  local input_serial = serialise_inputs(merged_input)
+  local hash_source = source
+  if input_serial ~= '' then
+    hash_source = hash_source .. '|input:' .. input_serial
+  end
+  hash_source = hash_source .. '|opts:' .. serialise_opts(opts)
+  local import_content = collect_import_content(source, resolved_root, {})
+  if import_content ~= '' then
+    hash_source = hash_source .. '|imports:' .. import_content
+  end
+  return hash_source
+end
+
+--- Append the CLI flags common to every compile path: --font-path, --package-path,
+--- and a deterministically-ordered --input for each merged input variable.
+--- @param args table Argument list to append to (modified in place)
+--- @param merged_input table Merged input variables
+local function append_cli_common_args(args, merged_input)
+  local font_paths = global_config['font-path']
+  if font_paths then
+    for _, p in ipairs(font_paths) do
+      args[#args + 1] = '--font-path'
+      args[#args + 1] = paths.resolve_project_path(p)
+    end
+  end
+  if global_config['package-path'] then
+    args[#args + 1] = '--package-path'
+    args[#args + 1] = paths.resolve_project_path(global_config['package-path'])
+  end
+  local sorted_keys = {}
+  for k in pairs(merged_input) do
+    sorted_keys[#sorted_keys + 1] = k
+  end
+  table.sort(sorted_keys)
+  for _, k in ipairs(sorted_keys) do
+    args[#args + 1] = '--input'
+    args[#args + 1] = k .. '=' .. merged_input[k]
+  end
+end
+
 --- Compile Typst source to an image file (or multiple files for multi-page output).
 --- Uses stdin to pass source code, avoiding temporary .typ files.
 --- @param source string Full Typst source code
@@ -1077,18 +1163,7 @@ local function compile_typst(source, opts, img_format)
 
   -- Merge global and per-block input variables
   local merged_input = merge_inputs(opts.input, opts._block_input)
-  local input_serial = serialise_inputs(merged_input)
-
-  -- Build cache hash material: source + inputs + all merged options + imported file contents
-  local hash_source = source
-  if input_serial ~= '' then
-    hash_source = hash_source .. '|input:' .. input_serial
-  end
-  hash_source = hash_source .. '|opts:' .. serialise_opts(opts)
-  local import_content = collect_import_content(source, resolved_root, {})
-  if import_content ~= '' then
-    hash_source = hash_source .. '|imports:' .. import_content
-  end
+  local hash_source = build_hash_source(source, opts, resolved_root, merged_input)
 
   local use_cache = opts.cache ~= false
   local stem = compute_cache_stem(hash_source, img_format, dpi, opts.label, opts._inline)
@@ -1132,32 +1207,7 @@ local function compile_typst(source, opts, img_format)
   end
 
   local args = { 'compile', '--format', img_format, '--ppi', dpi, '--root', resolved_root }
-
-  -- Add --font-path flags (global-only; always a list after get_configuration)
-  local font_paths = global_config['font-path']
-  if font_paths then
-    for _, p in ipairs(font_paths) do
-      args[#args + 1] = '--font-path'
-      args[#args + 1] = paths.resolve_project_path(p)
-    end
-  end
-
-  -- Add --package-path if specified (global-only)
-  if global_config['package-path'] then
-    args[#args + 1] = '--package-path'
-    args[#args + 1] = paths.resolve_project_path(global_config['package-path'])
-  end
-
-  -- Add --input flags for each input variable
-  local sorted_keys = {}
-  for k in pairs(merged_input) do
-    sorted_keys[#sorted_keys + 1] = k
-  end
-  table.sort(sorted_keys)
-  for _, k in ipairs(sorted_keys) do
-    args[#args + 1] = '--input'
-    args[#args + 1] = k .. '=' .. merged_input[k]
-  end
+  append_cli_common_args(args, merged_input)
 
   -- Expose document colours to library theme functions via sys.inputs.
   -- Only hex colours (rgb("#RRGGBB")) can be round-tripped through a CLI flag;
@@ -1202,6 +1252,61 @@ local function compile_typst(source, opts, img_format)
     log.log_error(EXTENSION_NAME, 'Compiled file not found: ' .. abs_output)
     return nil
   end
+end
+
+--- Compile Typst source to native HTML (Typst >= 0.15, experimental).
+--- Caches the compiled `.html` alongside the image cache and injects the
+--- Typst head CSS once. Returns the inner `<body>` content.
+--- @param source string Full Typst source (from build_typst_source(code, opts, false))
+--- @param opts table Merged options
+--- @return string|nil Body inner HTML, or nil on failure
+--- @return boolean|nil true when compilation failed
+local function compile_typst_html(source, opts)
+  local bin = resolve_typst_bin()
+  if not bin then
+    return nil
+  end
+
+  local resolved_root = pandoc.path.normalize(resolve_to_absolute(global_config.root or '.'))
+  local merged_input = merge_inputs(opts.input, opts._block_input)
+  local hash_source = build_hash_source(source, opts, resolved_root, merged_input)
+
+  local use_cache = opts.cache ~= false
+  local stem = compute_cache_stem(hash_source, 'html', '0', opts.label, opts._inline)
+  local abs_cache = ensure_cache_dir()
+  if not abs_cache then
+    return nil
+  end
+  used_cache_formats['html'] = true
+  local abs_output = pandoc.path.join({ abs_cache, stem .. '.html' })
+
+  if use_cache then
+    local cached = typst_cli.read_file(abs_output)
+    if cached then
+      used_cache_files[stem .. '.html'] = true
+      typst_cli.inject_head_style_once(cached)
+      return typst_cli.extract_body(cached)
+    end
+  end
+
+  local args = { 'compile', '--format', 'html', '--features', 'html', '--root', resolved_root }
+  append_cli_common_args(args, merged_input)
+  args[#args + 1] = '-'
+  args[#args + 1] = abs_output
+
+  local ok = pcall(pandoc.pipe, bin, args, source)
+  if not ok then
+    return nil, true
+  end
+
+  local html = typst_cli.read_file(abs_output)
+  if not html then
+    log.log_error(EXTENSION_NAME, 'Compiled HTML not found: ' .. abs_output)
+    return nil
+  end
+  used_cache_files[stem .. '.html'] = true
+  typst_cli.inject_head_style_once(html)
+  return typst_cli.extract_body(html)
 end
 
 --- Map from cross-reference prefix to Quarto FloatRefTarget type name.
@@ -1341,6 +1446,25 @@ end
 --- @return boolean|nil true when compilation failed
 --- @return string|nil Full Typst source actually compiled (preamble + colour vars + code)
 local function compile_to_result(code, opts, img_format)
+  if img_format == 'html' then
+    local html_source = build_typst_source(code, opts, false)
+    local body, compile_err = compile_typst_html(html_source, opts)
+    if not body then
+      return nil, nil, compile_err, html_source
+    end
+    local classes = { 'typst-html' }
+    if type(opts.classes) == 'string' and opts.classes ~= '' then
+      for cls in opts.classes:gmatch('%S+') do
+        classes[#classes + 1] = cls
+      end
+    end
+    local block = pandoc.Div(
+      pandoc.Blocks({ pandoc.RawBlock('html', body) }),
+      pandoc.Attr('', classes, {})
+    )
+    return wrap_alignment(block, opts), nil, nil, html_source
+  end
+
   local full_source = build_typst_source(code, opts)
   local all_pages, compile_err = compile_typst(full_source, opts, img_format)
 
@@ -1420,13 +1544,7 @@ local function get_configuration(meta)
   read_file_cache = {}
 
   -- Build per-document cache subdirectory from the input file stem
-  local doc_stem = 'default'
-  local input_file = quarto.doc.input_file
-  if input_file and input_file ~= '' then
-    local input_name = pandoc.path.filename(input_file)
-    doc_stem = input_name:match('^(.+)%.[^.]+$') or input_name
-  end
-  cache_subdir = pandoc.path.join({ CACHE_BASE, doc_stem })
+  cache_subdir = typst_cli.doc_cache_subdir()
 
   -- Detect brand mode from document metadata (used for colour resolution)
   global_brand_mode = (meta['brand-mode'] and pandoc.utils.stringify(meta['brand-mode']) == 'dark')
@@ -1773,6 +1891,10 @@ local function process_codeblock(el)
     img_format = get_image_format_for_output()
   end
 
+  -- Native HTML output requires HTML-based output and Typst >= 0.15; otherwise
+  -- fall back to an image format with a warning.
+  img_format = resolve_html_format(img_format)
+
   -- Warn about PDF in HTML
   if img_format == 'pdf' and quarto.format.is_html_output() then
     log.log_warning(
@@ -1782,8 +1904,17 @@ local function process_codeblock(el)
     img_format = 'png'
   end
 
-  -- Dual-mode rendering for HTML/Reveal.js when both light and dark colours are present
-  local dual_mode = quarto.format.is_html_output() and has_dual_mode_colours(opts)
+  -- Dual-mode rendering for HTML/Reveal.js when both light and dark colours are present.
+  -- Native HTML output renders once (colours apply via the Typst source, not CSS classes).
+  local dual_mode = img_format ~= 'html'
+    and quarto.format.is_html_output()
+    and has_dual_mode_colours(opts)
+  if img_format == 'html' and has_dual_mode_colours(opts) then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Dual light/dark colours are not supported with format "html"; using the document brand mode.'
+    )
+  end
 
   local result
   if dual_mode then
@@ -1911,6 +2042,21 @@ local function process_codeblock(el)
   return result
 end
 
+--- Wrap inline native-HTML output in a typst-inline span.
+--- @param inner string Inline HTML (paragraph wrapper already stripped)
+--- @param opts table Merged options
+--- @return pandoc.Inline Inline raw HTML element
+local function create_inline_html_element(inner, opts)
+  local extra_classes = ''
+  if type(opts.classes) == 'string' and opts.classes ~= '' then
+    extra_classes = ' ' .. opts.classes
+  end
+  return pandoc.RawInline(
+    'html',
+    '<span class="typst-inline' .. extra_classes .. '">' .. inner .. '</span>'
+  )
+end
+
 --- Create a bare inline Image element from a compiled image.
 --- Emits format-specific raw markup to size the image to match
 --- surrounding text (height: 1em, auto width, vertical centring).
@@ -2034,6 +2180,16 @@ local function process_inline_code(el)
   end
   if not img_format then
     img_format = get_image_format_for_output()
+  end
+  img_format = resolve_html_format(img_format)
+  if img_format == 'html' then
+    local html_source = build_typst_source(code, opts, false)
+    local body = compile_typst_html(html_source, opts)
+    if not body then
+      log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
+      return el
+    end
+    return create_inline_html_element(typst_cli.strip_paragraph(body), opts)
   end
   if img_format == 'pdf' and quarto.format.is_html_output() then
     img_format = 'png'

--- a/example.qmd
+++ b/example.qmd
@@ -755,7 +755,7 @@ extensions:
 
 | Option             | Type            | Default   | Description                                                                                   |
 | ------------------ | --------------- | --------- | --------------------------------------------------------------------------------------------- |
-| `format`           | string          | (auto)    | Image format: `png`, `svg`, `pdf`.                                                            |
+| `format`           | string          | (auto)    | Output format: `png`, `svg`, `pdf`, or `html` (native HTML for HTML-based output).             |
 | `dpi`              | number          | `144`     | Pixels per inch (PNG only).                                                                   |
 | `width`            | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                               |
 | `height`           | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                              |
@@ -763,7 +763,7 @@ extensions:
 | `background`       | string\|object  | `"none"`  | Page fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map. |
 | `foreground`       | string\|object  | (none)    | Text fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map. |
 | `preamble`         | string          | `""`      | Typst code or path to a `.typ` file prepended before user code.                               |
-| `cache`            | boolean\|string | `true`    | Cache compiled images. Use `"clean"` to also remove stale cache files.                        |
+| `cache`            | boolean         | `true`    | Cache compiled images. Set `false` to skip the cache (existing files are preserved).          |
 | `input`            | object          | (none)    | Key-value pairs passed as `--input` flags to Typst CLI.                                       |
 | `file`             | string          | (none)    | Path to external `.typ` file to render.                                                       |
 | `output-directory` | string          | (none)    | Directory for saving compiled images.                                                         |

--- a/example.qmd
+++ b/example.qmd
@@ -65,11 +65,11 @@ format-links:
   - pptx
 engine: markdown
 filters:
-  - path: typst-render
-    at: pre-quarto
+  - typst-render
 extensions:
   typst-render:
     margin: "0.5em"
+    math: typst
 ---
 
 ::: {.content-hidden when-format="revealjs" when-format="pptx"}
@@ -99,13 +99,7 @@ filters:
   - typst-render
 ```
 
-For cross-referencing support, use timing control:
-
-```yaml
-filters:
-  - path: typst-render
-    at: pre-quarto
-```
+The extension registers its filters at the pipeline stages it needs (cross-referencing and the `math: typst` equation takeover both depend on this), so reference it by name and do not pin it to a single stage with `at:`.
 
 Then write Typst code blocks in your document:
 
@@ -194,6 +188,33 @@ Control horizontal alignment of the rendered image block.
 #set text(size: 14pt)
 A centred block.
 ```
+
+## Native HTML Output
+
+For HTML-based output, `format: html` renders a block to native HTML (semantic markup with MathML maths) instead of an image, using Typst's HTML export.
+It requires a Typst >= 0.15 binary via `QUARTO_TYPST`; otherwise, and for non-HTML output, it falls back to an image.
+
+```{typst}
+//| echo: fenced
+//| format: html
+#set text(size: 14pt)
+A *Typst* paragraph with maths $f(x) = sum_(i=0)^n x_i$ rendered as MathML.
+```
+
+This document also enables the global `math: typst` option, which takes over every document equation (`$...$` and `$$...$$`), treating its contents as Typst math syntax: native MathML for HTML output and unchanged passthrough for Typst output, with Quarto numbering and `@eq-` cross-references preserved.
+It applies to HTML and Typst output only, so the equations below use conditional content (`when-format`) to stay out of the LaTeX, DOCX, and PPTX renders, where Typst syntax would be misread as LaTeX.
+
+::: {.content-visible when-format="html" when-format="revealjs" when-format="typst"}
+
+Inline $f(x) = sum_(i=0)^n x_i$ sits in the text, and a numbered display equation follows:
+
+$$
+e^(i pi) + 1 = 0
+$$ {#eq-euler}
+
+See @eq-euler for Euler's identity.
+
+:::
 
 ## Cross-Referencing
 

--- a/example.qmd
+++ b/example.qmd
@@ -206,6 +206,18 @@ It applies to HTML and Typst output only, so the equations below use conditional
 
 ::: {.content-visible when-format="html" when-format="revealjs" when-format="typst"}
 
+### Math as Typst
+
+```typ
+Inline $f(x) = sum_(i=0)^n x_i$ sits in the text, and a numbered display equation follows:
+
+$$
+e^(i pi) + 1 = 0
+$$ {#eq-euler}
+
+See @eq-euler for Euler's identity.
+```
+
 Inline $f(x) = sum_(i=0)^n x_i$ sits in the text, and a numbered display equation follows:
 
 $$
@@ -292,6 +304,10 @@ $ sum_(k=1)^n k = (n(n+1))/2 $ // <2>
 
 1. Set the text size.
 2. The sum of the first `n` integers.
+
+::: {.content-visible when-format="revealjs"}
+### Code Annotations
+:::
 
 Code annotations compose with `code-fold` for HTML-based output.
 
@@ -441,6 +457,10 @@ Supports scalars, strings, booleans, arrays, nested objects, R data frames (colu
 This document uses the markdown engine; the snippets below are illustrative.
 For an executable demo, switch the document `engine` to `knitr` (R) or `jupyter` (Python) and copy the helper from `_extensions/mcanouil/typst-render/_resources/` (once installed): `typst_define.R` or `typst_define.py`.
 
+::: {.content-visible when-format="revealjs"}
+## Passing Data from R/Python
+:::
+
 R (knitr engine):
 
 ````markdown
@@ -468,6 +488,10 @@ n = #typst_define.n
 )
 ```
 ````
+
+::: {.content-visible when-format="revealjs"}
+## Passing Data from R/Python
+:::
 
 Python (jupyter engine):
 


### PR DESCRIPTION
Adds a `html` value for the `format` option that renders `{typst}` blocks and inline expressions to native HTML using Typst 0.15 HTML export, so maths become MathML and prose becomes selectable semantic HTML for HTML and Reveal.js output. It requires a Typst >= 0.15 binary via `QUARTO_TYPST` and falls back to SVG otherwise; content that relies on layout must be wrapped in Typst's `html.frame`.

A global `math: typst` option takes over every document equation, treating `$...$` and `$$...$$` as Typst math syntax: native MathML for HTML output and verbatim passthrough for Typst output, with Quarto equation numbering and `@eq-` cross-references preserved. On an older Typst it leaves Quarto's math renderer in place.

Shared Typst CLI helpers live in a new `_modules/typst-cli.lua`, and the equation takeover runs as a post-quarto filter so it sees Quarto's numbered equations. Reference the extension by name without an `at:` stage so its filters run at their declared stages.