### PR TITLE
feat: add code-line-numbers for echoed Typst source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### New Features
 
 - feat: add a `code-line-numbers` option for echoed Typst source.
-  With `echo: true`, a value such as `"1|3-4"` drives progressive line highlighting in Reveal.js (and `true` numbers every line), mirroring Quarto's native code blocks; the attribute is handled by Quarto's own line-numbers pass, so other formats fall back to static numbering and `echo: fenced` ignores it.
 
 ## 0.18.0 (2026-06-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: add a `code-line-numbers` option for echoed Typst source.
+  With `echo: true`, a value such as `"1|3-4"` drives progressive line highlighting in Reveal.js (and `true` numbers every line), mirroring Quarto's native code blocks; the attribute is handled by Quarto's own line-numbers pass, so other formats fall back to static numbering and `echo: fenced` ignores it.
+
 ## 0.18.0 (2026-06-17)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ $ E = m c^2 $                // <2>
 Code annotations are honoured only for `echo: true`; with `echo: false` or `echo: fenced` the `// <N>` markers are stripped and annotations are ignored.
 Annotations compose with `code-fold`.
 
+With `echo: true`, highlight lines of the echoed source with `code-line-numbers`, mirroring Quarto's native [code line numbers](https://quarto.org/docs/presentations/revealjs/#line-highlighting).
+Use a string of steps for progressive line highlighting in Reveal.js (steps separated by `|`, ranges with `-`, sets with `,`):
+
+````markdown
+```{typst}
+//| echo: true
+//| code-line-numbers: "1|2"
+#set text(size: 14pt)
+$ E = m c^2 $
+```
+````
+
+`code-line-numbers: true` numbers every line. The attribute is passed to Quarto's own line-numbers pass, so animated highlighting applies in Reveal.js while other formats fall back to static numbering. It is ignored for `echo: fenced`.
+
 ### External File Rendering
 
 Render an external `.typ` file instead of inline code:
@@ -467,34 +481,35 @@ See @eq-pythagoras.
 
 ### Options
 
-| Option             | Type            | Default   | Description                                                                                                         |
-| ------------------ | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------- |
-| `format`           | string          | (auto)    | Output format: `png`, `svg`, `pdf`, or `html`. See [Native HTML Output](#native-html-output).                       |
-| `dpi`              | number          | `144`     | Pixels per inch (PNG only).                                                                                         |
-| `width`            | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                                                     |
-| `height`           | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                                                    |
-| `margin`           | string          | `"0.5em"` | Page margin for image compilation; block `inset` with `output: asis`.                                               |
-| `background`       | string\|object  | `"none"`  | Page fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map.                       |
-| `foreground`       | string\|object  | (none)    | Text fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map.                       |
-| `preamble`         | string          | `""`      | Typst code or path to a `.typ` file prepended before user code.                                                     |
-| `cache`            | boolean         | `true`    | Cache compiled images. Set `false` to skip cache (existing files are preserved).                                    |
-| `cache-refresh`    | boolean         | `false`   | Remove stale cache files after each render (global only).                                                           |
-| `input`            | object          | (none)    | Key-value pairs passed as `--input` flags to Typst CLI.                                                             |
-| `file`             | string          | (none)    | Path to external `.typ` file to render.                                                                             |
-| `output-directory` | string          | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).                                    |
-| `output-filename`  | string          | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted.                  |
-| `output-source`    | boolean         | `false`   | Also write the compiled Typst source next to each saved image. Requires `output-directory` or `output-filename`.    |
-| `echo`             | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`). `true` honours code annotations on the source. |
-| `code-fold`        | boolean\|string | `false`   | Collapse the echoed source in a `<details>` block (HTML only). Use `show` to render expanded.                       |
-| `code-summary`     | string          | `"Code"`  | Summary text for the `code-fold` `<details>` block (HTML only).                                                     |
-| `eval`             | boolean         | `true`    | Compile Typst code to image.                                                                                        |
-| `include`          | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                                                          |
-| `output`           | boolean\|string | `true`    | Show rendered output. Use `asis` for native Typst passthrough.                                                      |
-| `output-location`  | string          | (none)    | Output placement in Reveal.js (`fragment`, `slide`, `column`, `column-fragment`).                                   |
-| `classes`          | string          | (none)    | Space-separated CSS classes on the output image (e.g., `r-stretch`).                                                |
-| `pages`            | string          | `"all"`   | Pages to include from multi-page output: `all`, `1`, `1-3`, `2,5`, `3-`.                                            |
-| `layout-ncol`      | string          | (none)    | Number of columns for arranging multi-page output. Omit for vertical stack.                                         |
-| `align`            | string          | (none)    | Horizontal alignment: `left`, `center`, `right`, `default`.                                                         |
+| Option              | Type            | Default   | Description                                                                                                         |
+| ------------------- | --------------- | --------- | ------------------------------------------------------------------------------------------------------------------- |
+| `format`            | string          | (auto)    | Output format: `png`, `svg`, `pdf`, or `html`. See [Native HTML Output](#native-html-output).                       |
+| `dpi`               | number          | `144`     | Pixels per inch (PNG only).                                                                                         |
+| `width`             | string          | `"auto"`  | Page width for image compilation (ignored with `output: asis`).                                                     |
+| `height`            | string          | `"auto"`  | Page height for image compilation (ignored with `output: asis`).                                                    |
+| `margin`            | string          | `"0.5em"` | Page margin for image compilation; block `inset` with `output: asis`.                                               |
+| `background`        | string\|object  | `"none"`  | Page fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map.                       |
+| `foreground`        | string\|object  | (none)    | Text fill colour. Accepts a Typst colour, `auto` (from `_brand.yml`), or `{light, dark}` map.                       |
+| `preamble`          | string          | `""`      | Typst code or path to a `.typ` file prepended before user code.                                                     |
+| `cache`             | boolean         | `true`    | Cache compiled images. Set `false` to skip cache (existing files are preserved).                                    |
+| `cache-refresh`     | boolean         | `false`   | Remove stale cache files after each render (global only).                                                           |
+| `input`             | object          | (none)    | Key-value pairs passed as `--input` flags to Typst CLI.                                                             |
+| `file`              | string          | (none)    | Path to external `.typ` file to render.                                                                             |
+| `output-directory`  | string          | (none)    | Directory for saving compiled images. See [Output Directory](#output-directory).                                    |
+| `output-filename`   | string          | (none)    | Filename for the saved image. Leading `/` overrides `output-directory`. Auto-generated if omitted.                  |
+| `output-source`     | boolean         | `false`   | Also write the compiled Typst source next to each saved image. Requires `output-directory` or `output-filename`.    |
+| `echo`              | boolean\|string | `false`   | Show Typst source code alongside output (`true`, `false`, `fenced`). `true` honours code annotations on the source. |
+| `code-fold`         | boolean\|string | `false`   | Collapse the echoed source in a `<details>` block (HTML only). Use `show` to render expanded.                       |
+| `code-summary`      | string          | `"Code"`  | Summary text for the `code-fold` `<details>` block (HTML only).                                                     |
+| `code-line-numbers` | boolean\|string | `false`   | Highlight echoed source lines (e.g. `1\|3-4`) for Reveal.js. Requires `echo: true`.                                 |
+| `eval`              | boolean         | `true`    | Compile Typst code to image.                                                                                        |
+| `include`           | boolean         | `true`    | Include block in output. Set `false` to suppress entirely.                                                          |
+| `output`            | boolean\|string | `true`    | Show rendered output. Use `asis` for native Typst passthrough.                                                      |
+| `output-location`   | string          | (none)    | Output placement in Reveal.js (`fragment`, `slide`, `column`, `column-fragment`).                                   |
+| `classes`           | string          | (none)    | Space-separated CSS classes on the output image (e.g., `r-stretch`).                                                |
+| `pages`             | string          | `"all"`   | Pages to include from multi-page output: `all`, `1`, `1-3`, `2,5`, `3-`.                                            |
+| `layout-ncol`       | string          | (none)    | Number of columns for arranging multi-page output. Omit for vertical stack.                                         |
+| `align`             | string          | (none)    | Horizontal alignment: `left`, `center`, `right`, `default`.                                                         |
 
 Any unknown option with a string value is forwarded as an HTML attribute on the output image element (e.g., `//| style: "max-height: 300px;"`).
 Values that look like booleans (`true`/`false`) must be quoted to be forwarded (e.g., `//| data-lazy: "true"`).

--- a/README.md
+++ b/README.md
@@ -457,6 +457,12 @@ Requirements and caveats:
 - Content that relies on layout (shapes, absolute positioning) does not translate to semantic HTML.
   Wrap such content in Typst's `html.frame` to embed it as inline SVG.
 
+> [!DANGER]
+> Do not use in production yet:
+>
+> - Typst HTML export is experimental and not yet stable.
+> - `QUARTO_TYPST` is an internal development feature that might break current Quarto Typst behaviour.
+
 ### Typst Equations
 
 Set the global `math: typst` option to treat every document equation (`$...$` and `$$...$$`) as **Typst** math syntax rather than LaTeX.

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Requirements and caveats:
 - Content that relies on layout (shapes, absolute positioning) does not translate to semantic HTML.
   Wrap such content in Typst's `html.frame` to embed it as inline SVG.
 
-> [!DANGER]
+> [!CAUTION]
 > Do not use in production yet:
 >
 > - Typst HTML export is experimental and not yet stable.

--- a/_extensions/typst-render/_modules/code-cell.lua
+++ b/_extensions/typst-render/_modules/code-cell.lua
@@ -178,8 +178,10 @@ function M.new(config)
   --- @param fold table|nil `{ open = boolean, summary = string|nil }` for code-fold
   --- @param result pandoc.Block|nil Rendered output to place after/within the source
   --- @param annotate boolean|nil Keep annotation markers for Quarto to process
+  --- @param line_numbers string|nil `code-line-numbers` value for Quarto to process
+  ---   (e.g. `"true"` or `"1|3-4"`); attached to the language CodeBlock unless fenced
   --- @return pandoc.Blocks The source listing, optionally wrapped in a `cell` Div
-  function cell.create_echo_block(code, fenced, option_lines, fold, result, annotate)
+  function cell.create_echo_block(code, fenced, option_lines, fold, result, annotate, line_numbers)
     if not annotate then
       code = cell.strip_annotations(code)
     end
@@ -217,11 +219,17 @@ function M.new(config)
       classes = { class_name }
     end
 
+    -- Line numbers attach only to the Typst source CodeBlock, never to the
+    -- fenced `markdown` display (whose lines are the fence, not the source).
+    local attrs = {}
+    if line_numbers and not fenced then
+      attrs['code-line-numbers'] = line_numbers
+    end
+
     -- The native cell shape is required for code-fold (attribute-driven, gated
     -- to HTML by Quarto) and for code-annotations (markers linked downstream).
     if fold or annotate then
       classes[#classes + 1] = 'cell-code'
-      local attrs = {}
       if fold then
         attrs['code-fold'] = fold.open and 'show' or 'true'
         local summary = fold.summary
@@ -237,7 +245,7 @@ function M.new(config)
       return pandoc.Blocks({ pandoc.Div(children, pandoc.Attr('', { 'cell' }, {})) })
     end
 
-    local blocks = pandoc.Blocks({ pandoc.CodeBlock(text, pandoc.Attr('', classes, {})) })
+    local blocks = pandoc.Blocks({ pandoc.CodeBlock(text, pandoc.Attr('', classes, attrs)) })
     if result then
       blocks:insert(result)
     end

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -8,11 +8,11 @@ options:
   format:
     type: string
     enum: [png, svg, pdf, html]
-    description: "Output format. Auto-detected from output format if not set. Use 'html' for native HTML (semantic markup with MathML maths) in HTML-based output; it requires Typst >= 0.15 (set QUARTO_TYPST to a Typst >= 0.15 binary) and falls back to SVG otherwise."
+    description: "Output format. Auto-detected from output format if not set. Use 'html' for native HTML (semantic markup with MathML maths) in HTML-based output; it requires Typst >= 0.15 and falls back to SVG otherwise."
   math:
     type: string
     enum: [typst]
-    description: "Global only. Set to 'typst' to render every document equation ($...$ and $$...$$) as Typst math syntax (not LaTeX). For HTML output the maths become native MathML (requires Typst >= 0.15 via QUARTO_TYPST, else Quarto's renderer is kept); for Typst output the maths pass through unchanged. Quarto equation numbering and cross-references keep working."
+    description: "Global only. Set to 'typst' to render every document equation ($...$ and $$...$$) as Typst math syntax (not LaTeX). For HTML output the maths become native MathML (requires Typst >= 0.15); for Typst output the maths pass through unchanged. Quarto equation numbering and cross-references keep working."
   dpi:
     type: integer
     default: 144
@@ -104,6 +104,10 @@ options:
     type: string
     default: "Code"
     description: "Summary text for the code-fold <details> block, rendered as Markdown (HTML output only)."
+  code-line-numbers:
+    type: [boolean, string]
+    default: false
+    description: "Highlight lines of the echoed source. Use a string like '1|3-4' for progressive line highlighting in Reveal.js (steps separated by '|', ranges with '-', sets with ','). Requires echo: true."
   eval:
     type: boolean
     default: true
@@ -215,6 +219,9 @@ attributes:
     code-summary:
       type: string
       description: "Summary text for the code-fold <details> block, rendered as Markdown (HTML output only)."
+    code-line-numbers:
+      type: [boolean, string]
+      description: "Highlight lines of the echoed source. Use a string like '1|3-4' for progressive line highlighting in Reveal.js (steps separated by '|', ranges with '-', sets with ','). Requires echo: true."
     eval:
       type: boolean
       description: "Compile this block to image."

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -156,7 +156,7 @@ attributes:
     format:
       type: string
       enum: [png, svg, pdf, html]
-      description: "Output format for this block. Use 'html' for native HTML (semantic markup with MathML maths) in HTML-based output; requires Typst >= 0.15 (set QUARTO_TYPST), falls back to SVG otherwise."
+      description: "Output format for this block. Use 'html' for native HTML (semantic markup with MathML maths) in HTML-based output; requires Typst >= 0.15."
     dpi:
       type: integer
       exclusiveMinimum: 0

--- a/_extensions/typst-render/typst-math.lua
+++ b/_extensions/typst-render/typst-math.lua
@@ -230,11 +230,7 @@ local function configure(meta)
     if typst_cli.supports_html(typst_cli.resolve_bin()) then
       html_mode = true
     else
-      log.log_warning(
-        EXTENSION_NAME,
-        'math: typst requires Typst >= 0.15 for HTML output. Set QUARTO_TYPST to a Typst >= 0.15 '
-        .. 'binary to enable native MathML; leaving Quarto math rendering in place.'
-      )
+      log.log_warning(EXTENSION_NAME, '\'math: typst\' requires Typst >= 0.15 for HTML output.')
     end
   end
 

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -51,6 +51,7 @@ local DEFAULTS = {
   echo = false,
   ['code-fold'] = false,
   ['code-summary'] = nil,
+  ['code-line-numbers'] = false,
   eval = true,
   include = true,
   output = true,
@@ -69,6 +70,7 @@ local KNOWN_KEYS = {
   cap = true,
   alt = true,
   ['code-summary'] = true,
+  ['code-line-numbers'] = true,
   _block_input = true,
   _inline = true,
   _alt = true,
@@ -527,11 +529,7 @@ local function resolve_html_format(img_format)
     return get_image_format_for_output()
   end
   if not typst_supports_html() then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Native HTML output requires Typst >= 0.15. Set QUARTO_TYPST to a Typst >= 0.15 '
-      .. 'binary to enable it; falling back to SVG.'
-    )
+    log.log_warning(EXTENSION_NAME, 'Native HTML output requires Typst >= 0.15.')
     return 'svg'
   end
   return 'html'
@@ -670,8 +668,8 @@ local function parse_pages(pages_str, total_pages)
 
   local seen = {}
   local result = {}
-  for part in pages_str:gmatch('[^,]+') do
-    part = part:match('^%s*(.-)%s*$')
+  for raw_part in pages_str:gmatch('[^,]+') do
+    local part = raw_part:match('^%s*(.-)%s*$')
     local lo, hi = part:match('^(%d+)%-(%d+)$')
     if not lo then
       local open_lo = part:match('^(%d+)%-$')
@@ -1566,7 +1564,7 @@ local function get_configuration(meta)
     -- so we use a separate key list to ensure 'format' etc. are not missed.
     local config_keys = {
       'format', 'dpi', 'width', 'height', 'margin',
-      'cache', 'cache-refresh', 'echo', 'code-fold', 'code-summary',
+      'cache', 'cache-refresh', 'echo', 'code-fold', 'code-summary', 'code-line-numbers',
       'eval', 'include', 'output', 'output-location', 'classes',
       'root', 'package-path', 'pages', 'layout-ncol', 'align',
       'output-directory', 'output-source',
@@ -1603,6 +1601,21 @@ local function get_configuration(meta)
                 'Invalid code-fold value "' .. str .. '"; expected true, false, or show. Disabling code-fold.'
               )
               global_config[k] = false
+            end
+          end
+        elseif k == 'code-line-numbers' then
+          -- Boolean stays as-is; "true"/"false" map to booleans; any other
+          -- string (e.g. "1|3-4") is kept verbatim for Quarto's line-numbers pass.
+          if type(val) == 'boolean' then
+            global_config[k] = val
+          else
+            local str = pandoc.utils.stringify(val)
+            if str == 'true' then
+              global_config[k] = true
+            elseif str == 'false' then
+              global_config[k] = false
+            else
+              global_config[k] = str
             end
           end
         elseif k == 'output' then
@@ -1793,6 +1806,14 @@ local function process_codeblock(el)
     fold = { open = cf == 'show', summary = opts['code-summary'] }
   end
 
+  -- Code line numbers: attach the value to the echoed source so Quarto's
+  -- line-numbers pre-filter adds `number-lines` and reveal.js animation steps.
+  local cln = opts['code-line-numbers']
+  local line_numbers = nil
+  if cln ~= nil and cln ~= false then
+    line_numbers = tostring(cln)
+  end
+
   -- Handle eval/echo matrix: both false means hidden block
   if not do_eval and not do_echo then
     return pandoc.Null()
@@ -1821,13 +1842,13 @@ local function process_codeblock(el)
     if not do_include then
       return pandoc.Null()
     end
-    return cell.create_echo_block(code, is_fenced, option_lines, fold, nil, annotate)
+    return cell.create_echo_block(code, is_fenced, option_lines, fold, nil, annotate, line_numbers)
   end
 
   -- Output suppressed: skip compilation, show echo block only
   if output_mode == 'false' then
     if do_echo and do_include then
-      return cell.create_echo_block(code, is_fenced, option_lines, fold, nil, annotate)
+      return cell.create_echo_block(code, is_fenced, option_lines, fold, nil, annotate, line_numbers)
     end
     return pandoc.Null()
   end
@@ -1874,7 +1895,7 @@ local function process_codeblock(el)
     local result = cell.wrap_crossref(pandoc.RawBlock('typst', scoped_code), opts, REF_TYPE_NAMES)
     if do_echo then
       -- Native Typst pass-through does not support annotations; strip markers.
-      return cell.create_echo_block(code, is_fenced, option_lines, fold, result, false)
+      return cell.create_echo_block(code, is_fenced, option_lines, fold, result, false, line_numbers)
     end
     return result
   end
@@ -1931,7 +1952,7 @@ local function process_codeblock(el)
       end
       local error_block = create_error_block(block_id)
       if do_echo then
-        return cell.create_echo_block(code, is_fenced, option_lines, fold, error_block, annotate)
+        return cell.create_echo_block(code, is_fenced, option_lines, fold, error_block, annotate, line_numbers)
       end
       return error_block
     end
@@ -1994,7 +2015,7 @@ local function process_codeblock(el)
         end
         local error_block = create_error_block(block_id)
         if do_echo then
-          return cell.create_echo_block(code, is_fenced, option_lines, fold, error_block, annotate)
+          return cell.create_echo_block(code, is_fenced, option_lines, fold, error_block, annotate, line_numbers)
         end
         return error_block
       end
@@ -2031,13 +2052,13 @@ local function process_codeblock(el)
   if output_location then
     -- Reveal.js output-location layout does not support annotations; strip markers.
     local echo_block = do_echo
-      and cell.create_echo_block(code, is_fenced, option_lines, fold, nil, false)
+      and cell.create_echo_block(code, is_fenced, option_lines, fold, nil, false, line_numbers)
       or nil
     return cell.apply_output_location(echo_block, result, output_location)
   end
 
   if do_echo then
-    return cell.create_echo_block(code, is_fenced, option_lines, fold, result, annotate)
+    return cell.create_echo_block(code, is_fenced, option_lines, fold, result, annotate, line_numbers)
   end
 
   return result

--- a/example.qmd
+++ b/example.qmd
@@ -388,11 +388,23 @@ For all other formats, `output: asis` behaves the same as `output: true` (compil
 This block uses native passthrough in Typst output.
 ```
 
+## Code Line Numbers (Reveal.js)
+
+With `echo: true`, `code-line-numbers` highlights lines of the Typst source.
+A string of steps separated by `|` reveals the highlight progressively across fragments.
+
+```{typst}
+//| echo: true
+//| code-line-numbers: "1|2"
+#set text(size: 14pt)
+$ E = m c^2 $
+```
+
 ## Output Location (Reveal.js)
 
-::: {.content-visible when-format="revealjs"}
-
 The `output-location` option controls where rendered output appears in Reveal.js presentations.
+
+::: {.content-visible when-format="revealjs"}
 
 ### Fragment
 

--- a/example.qmd
+++ b/example.qmd
@@ -204,6 +204,13 @@ A *Typst* paragraph with maths $f(x) = sum_(i=0)^n x_i$ rendered as MathML.
 This document also enables the global `math: typst` option, which takes over every document equation (`$...$` and `$$...$$`), treating its contents as Typst math syntax: native MathML for HTML output and unchanged passthrough for Typst output, with Quarto numbering and `@eq-` cross-references preserved.
 It applies to HTML and Typst output only, so the equations below use conditional content (`when-format`) to stay out of the LaTeX, DOCX, and PPTX renders, where Typst syntax would be misread as LaTeX.
 
+::: {.callout-important}
+## Do not use in production yet
+
+- Typst HTML export is experimental and not yet stable.
+- `QUARTO_TYPST` is an internal development feature that might break current Quarto Typst behaviour.
+:::
+
 ::: {.content-visible when-format="html" when-format="revealjs" when-format="typst"}
 
 ### Math as Typst

--- a/example.qmd
+++ b/example.qmd
@@ -192,7 +192,7 @@ A centred block.
 ## Native HTML Output
 
 For HTML-based output, `format: html` renders a block to native HTML (semantic markup with MathML maths) instead of an image, using Typst's HTML export.
-It requires a Typst >= 0.15 binary via `QUARTO_TYPST`; otherwise, and for non-HTML output, it falls back to an image.
+It requires a Typst >= 0.15 binary via `QUARTO_TYPST` (**this is for development and early access, be aware other native features can break**); otherwise, and for non-HTML output, it falls back to an image.
 
 ```{typst}
 //| echo: fenced


### PR DESCRIPTION
Adds a `code-line-numbers` option (global and per-block) for the echoed `{typst}` source, mirroring Quarto's native code blocks.