### PR TITLE
chore: require Quarto >= 1.10.18 for bundled Typst 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- chore: require Quarto >= 1.10.18, which bundles Typst 0.15.
+  Native HTML output (`format: html`) and `math: typst` now work with the bundled Typst binary, so the `QUARTO_TYPST` environment variable is no longer needed for early access.
+
 ## 0.19.0 (2026-06-18)
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ A *Typst* paragraph with maths $f(x) = sum_(i=0)^n x_i$.
 Requirements and caveats:
 
 - Typst HTML export landed in Typst 0.15 and is experimental.
-  Quarto 1.9 bundles Typst 0.14, so set `QUARTO_TYPST` to a Typst >= 0.15 binary (**this is for development and early access, be aware other native features can break**), for example `QUARTO_TYPST=/path/to/typst quarto render`.
+  Quarto 1.10+ bundles Typst 0.15, so ensure your Quarto installation is up to date.
 - When the binary is older than 0.15, or the output is not HTML-based, the block falls back to an SVG image with a warning.
 - Content that relies on layout (shapes, absolute positioning) does not translate to semantic HTML.
   Wrap such content in Typst's `html.frame` to embed it as inline SVG.
@@ -461,7 +461,6 @@ Requirements and caveats:
 > Do not use in production yet:
 >
 > - Typst HTML export is experimental and not yet stable.
-> - `QUARTO_TYPST` is an internal development feature that might break current Quarto Typst behaviour.
 
 ### Typst Equations
 

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ A *Typst* paragraph with maths $f(x) = sum_(i=0)^n x_i$.
 Requirements and caveats:
 
 - Typst HTML export landed in Typst 0.15 and is experimental.
-  Quarto 1.10+ bundles Typst 0.15, so ensure your Quarto installation is up to date.
+  Quarto 1.10.18 and later bundle Typst 0.15, so ensure your Quarto installation is up to date.
 - When the binary is older than 0.15, or the output is not HTML-based, the block falls back to an SVG image with a warning.
 - Content that relies on layout (shapes, absolute positioning) does not translate to semantic HTML.
   Wrap such content in Typst's `html.frame` to embed it as inline SVG.

--- a/_extensions/typst-render/_extension.yml
+++ b/_extensions/typst-render/_extension.yml
@@ -1,7 +1,7 @@
 title: Typst Render
 author: Mickaël Canouil
 version: 0.19.0
-quarto-required: ">=1.6.0"
+quarto-required: ">=1.10.18"
 contributes:
   filters:
     - at: pre-quarto

--- a/_extensions/typst-render/typst-math.lua
+++ b/_extensions/typst-render/typst-math.lua
@@ -37,7 +37,7 @@ local html_cache = {}
 local function resolve_bin()
   local bin = typst_cli.resolve_bin()
   if not bin then
-    log.log_error(EXTENSION_NAME, 'Typst binary not found. Ensure Quarto >= 1.6 is installed.')
+    log.log_error(EXTENSION_NAME, 'Typst binary not found. Ensure Quarto >= 1.10.18 is installed.')
   end
   return bin
 end

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -495,7 +495,7 @@ local function resolve_typst_bin()
 
   typst_bin = typst_cli.resolve_bin()
   if not typst_bin then
-    log.log_error(EXTENSION_NAME, 'Typst binary not found. Ensure Quarto >= 1.6 is installed.')
+    log.log_error(EXTENSION_NAME, 'Typst binary not found. Ensure Quarto >= 1.10.18 is installed.')
   end
   return typst_bin
 end

--- a/example.qmd
+++ b/example.qmd
@@ -192,7 +192,6 @@ A centred block.
 ## Native HTML Output
 
 For HTML-based output, `format: html` renders a block to native HTML (semantic markup with MathML maths) instead of an image, using Typst's HTML export.
-It requires a Typst >= 0.15 binary via `QUARTO_TYPST` (**this is for development and early access, be aware other native features can break**); otherwise, and for non-HTML output, it falls back to an image.
 
 ```{typst}
 //| echo: fenced
@@ -208,7 +207,6 @@ It applies to HTML and Typst output only, so the equations below use conditional
 ## Do not use in production yet
 
 - Typst HTML export is experimental and not yet stable.
-- `QUARTO_TYPST` is an internal development feature that might break current Quarto Typst behaviour.
 :::
 
 ::: {.content-visible when-format="html" when-format="revealjs" when-format="typst"}

--- a/example.qmd
+++ b/example.qmd
@@ -192,6 +192,7 @@ A centred block.
 ## Native HTML Output
 
 For HTML-based output, `format: html` renders a block to native HTML (semantic markup with MathML maths) instead of an image, using Typst's HTML export.
+For non-HTML output, it falls back to an image.
 
 ```{typst}
 //| echo: fenced


### PR DESCRIPTION
Quarto 1.10.18 bundles Typst 0.15, so native HTML output (`format: html`) and the global `math: typst` option now work with the Typst binary that ships with Quarto.

The extension's `quarto-required` moves from `>=1.6.0` to `>=1.10.18`, the `QUARTO_TYPST` early-access instructions are removed from the README and the example document, and the binary-not-found error messages name the new minimum Quarto version.