### PR TITLE
feat: save inline images and default the output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.docx
 *.pptx
 *_files/
+**/assets/typst-render/
 .DS_Store
 
 **/*.quarto_ipynb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - feat: `output-directory` now defaults to `./assets/typst-render`, resolved relative to the document, instead of being unset.
   Compiled images are written into the project rather than kept only in the render cache under `.quarto/`, which a website does not copy to its output directory and therefore cannot serve once deployed.
   Set `output-directory: ""` to restore the previous behaviour.
+- fix: images named from a label or a block counter are written to a subdirectory of `output-directory` named after the document.
+  Two documents in one directory both produced `typst-block-1`, so whichever rendered last overwrote the other's image and one of the pages showed the wrong figure.
+  An explicit `output-filename` is unaffected.
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- feat: `output-directory` now defaults to `./assets/typst-render`, resolved relative to the document, instead of being unset.
+  Compiled images are written into the project rather than kept only in the render cache under `.quarto/`, which a website does not copy to its output directory and therefore cannot serve once deployed.
+  Set `output-directory: ""` to restore the previous behaviour.
+
+### New Features
+
+- feat: inline `{typst}` expressions honour `output-directory` and `output-source`, writing `typst-inline-<N>` files alongside the images compiled from blocks.
+
 ## 0.20.1 (2026-08-01)
 
 ### Documentation

--- a/_extensions/typst-render/_modules/typst-cli.lua
+++ b/_extensions/typst-render/_modules/typst-cli.lua
@@ -138,16 +138,21 @@ function M.reset_head_injection()
   head_injected = false
 end
 
---- Per-document cache subdirectory derived from the input file stem.
---- @return string Cache subdirectory (e.g. ".quarto/typst-render/index")
-function M.doc_cache_subdir()
-  local doc_stem = 'default'
+--- Stem of the document being rendered, used to namespace per-document files.
+--- @return string Document stem (e.g. "index"), or "default" when unknown
+function M.doc_stem()
   local input_file = quarto.doc.input_file
   if input_file and input_file ~= '' then
     local input_name = pandoc.path.filename(input_file)
-    doc_stem = input_name:match('^(.+)%.[^.]+$') or input_name
+    return input_name:match('^(.+)%.[^.]+$') or input_name
   end
-  return pandoc.path.join({ '.quarto/typst-render', doc_stem })
+  return 'default'
+end
+
+--- Per-document cache subdirectory derived from the input file stem.
+--- @return string Cache subdirectory (e.g. ".quarto/typst-render/index")
+function M.doc_cache_subdir()
+  return pandoc.path.join({ '.quarto/typst-render', M.doc_stem() })
 end
 
 return M

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -142,7 +142,7 @@ options:
   output-directory:
     type: string
     default: "./assets/typst-render"
-    description: "Default output directory for saving compiled images, resolved relative to the document directory. Per-block output-filename paths are resolved relative to this directory. Set to an empty string to write no image files, leaving them in the render cache."
+    description: "Default output directory for saving compiled images, resolved relative to the document directory. Images named from a label or a block counter are written to a subdirectory named after the document, so two documents in the same directory do not overwrite each other. Per-block output-filename paths are resolved relative to this directory, without that subdirectory. Set to an empty string to write no image files, leaving them in the render cache."
     completion:
       type: directory
   output-source:
@@ -202,7 +202,7 @@ attributes:
         type: directory
     output-filename:
       type: string
-      description: "Path to save the compiled image. Leading '/' means project root (ignores output-directory). Otherwise resolved relative to output-directory. Auto-generated from label or block counter if omitted."
+      description: "Path to save the compiled image. Leading '/' means project root (ignores output-directory). Otherwise resolved relative to output-directory, without the per-document subdirectory. Auto-generated from label or block counter if omitted."
       completion:
         type: file
         extensions: [.png, .svg, .pdf]

--- a/_extensions/typst-render/_schema.yml
+++ b/_extensions/typst-render/_schema.yml
@@ -141,13 +141,14 @@ options:
     description: "Horizontal alignment for the rendered image block."
   output-directory:
     type: string
-    description: "Default output directory for saving compiled images. Per-block output-filename paths are resolved relative to this directory."
+    default: "./assets/typst-render"
+    description: "Default output directory for saving compiled images, resolved relative to the document directory. Per-block output-filename paths are resolved relative to this directory. Set to an empty string to write no image files, leaving them in the render cache."
     completion:
       type: directory
   output-source:
     type: boolean
     default: false
-    description: "Also write the compiled Typst source (preamble + colour bindings + user code) next to each saved image, using the same stem with a .typ extension. Requires output-directory or output-filename to take effect."
+    description: "Also write the compiled Typst source (preamble + colour bindings + user code) next to each saved image, using the same stem with a .typ extension. Has no effect when image saving is disabled with an empty output-directory."
 
 # Per-block comment+pipe attributes (//| key: value).
 # These are parsed from the code block text, not from element attributes.
@@ -196,7 +197,7 @@ attributes:
         extensions: [.typ]
     output-directory:
       type: string
-      description: "Output directory for this block, overrides the global output-directory."
+      description: "Output directory for this block, overrides the global output-directory. Set to an empty string to write no image file for this block."
       completion:
         type: directory
     output-filename:
@@ -207,7 +208,7 @@ attributes:
         extensions: [.png, .svg, .pdf]
     output-source:
       type: boolean
-      description: "Also write the compiled Typst source for this block next to its saved image. Requires output-directory or output-filename to take effect."
+      description: "Also write the compiled Typst source for this block next to its saved image. Has no effect when image saving is disabled with an empty output-directory."
     echo:
       type: [boolean, string]
       enum: [true, false, fenced]

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -44,7 +44,7 @@ local DEFAULTS = {
   cache = true,
   ['cache-refresh'] = false,
   file = nil,
-  ['output-directory'] = nil,
+  ['output-directory'] = './assets/typst-render',
   ['output-filename'] = nil,
   ['output-source'] = false,
   input = nil,
@@ -2225,7 +2225,25 @@ local function process_inline_code(el)
     return el
   end
 
-  return create_inline_image_element(pages[1], opts)
+  -- Inline expressions carry no label or output-filename, so the image is named
+  -- from the inline counter. A failed copy falls back to the cache path so the
+  -- render still produces an image.
+  local img_path = pages[1]
+  local output_path = resolve_output_path(
+    global_config['output-directory'], opts['output-directory'],
+    nil, nil, inline_id, img_format
+  )
+  if output_path then
+    local out_pages = save_output_files({ img_path }, output_path, nil, img_format)
+    if out_pages then
+      img_path = out_pages[1]
+    end
+    if opts['output-source'] == true then
+      save_source_file(full_source, output_path, nil)
+    end
+  end
+
+  return create_inline_image_element(img_path, opts)
 end
 
 --- Remove stale cache files after all blocks have been processed.

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -933,7 +933,8 @@ end
 local function resolve_output_path(global_dir, block_dir, block_filename, label, counter_name, img_format)
   -- Determine the filename
   local filename = block_filename
-  if not filename or filename == '' then
+  local auto_named = not filename or filename == ''
+  if auto_named then
     -- Auto-generate from label or counter
     local stem = (type(label) == 'string' and label ~= '') and label or counter_name
     filename = stem .. '.' .. img_format
@@ -954,8 +955,13 @@ local function resolve_output_path(global_dir, block_dir, block_filename, label,
     return nil
   end
 
-  -- Join directory and filename
-  local joined = pandoc.path.join({ dir, filename })
+  -- Labels and block counters are unique within a document only, so images
+  -- named from them go in a per-document subdirectory; two documents in the
+  -- same directory would otherwise overwrite each other's images. An explicit
+  -- output-filename is the author's own path and is left alone.
+  local joined = auto_named
+      and pandoc.path.join({ dir, typst_cli.doc_stem(), filename })
+      or pandoc.path.join({ dir, filename })
 
   return resolve_to_absolute(joined)
 end

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -122,4 +122,3 @@ extensions:
       style-navbar-tools: false
   typst-render:
     format: svg
-    output-directory: "./images"

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -96,15 +96,6 @@ Blocks work normally.
 
 Per-block options use the comment and pipe form, `//| key: value`, at the top of the block.
 
-## An interaction worth knowing
-
-::: {.callout-caution}
-This site does not run the `code-window` filter, unlike the others in this family.
-
-`code-window` claims ```` ```{typst} ```` blocks at `pre-quarto` and rewrites them into decorated code blocks, so `typst-render` never sees them and no figure is produced.
-Running both, the blocks come out as ordinary listings with `{typst}` as their filename.
-:::
-
 ## Source
 
 The repository ships a short, standalone starting point you can copy: [`example.qmd`](https://github.com/mcanouil/quarto-typst-render/blob/main/example.qmd).

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -40,7 +40,7 @@ Set under `extensions.typst-render`.
 | `input` | | Key-value pairs passed as `--input`, readable through `sys.inputs`. |
 | `cache` | `true` | Cache compiled images between renders. |
 | `cache-refresh` | `false` | Remove stale cache files after each render. |
-| `output-directory` | `./assets/typst-render` | Where saved images are written, relative to the document. An empty string writes none, leaving them in the render cache where a deployed site cannot reach them. |
+| `output-directory` | `./assets/typst-render` | Where saved images are written, relative to the document, under a subdirectory named after it. An empty string writes none, leaving them in the render cache where a deployed site cannot reach them. |
 | `output-source` | `false` | Also write the compiled Typst source beside each image. |
 
 : Options under `extensions.typst-render`. {.striped .hover tbl-colwidths="[22,12,66]"}
@@ -80,7 +80,7 @@ A red word `{typst} #text(red)[hello]` in a sentence.
 ```
 
 An inline expression takes the options that shape the compilation, `format`, `dpi`, `background`, `foreground`, `preamble`, `input`, `cache`, `output`, `classes`, `output-directory`, and `output-source` among them.
-Its image is written as `typst-inline-<N>.<ext>`, numbered in document order.
+Its image is written as `typst-inline-<N>.<ext>`, numbered in document order, beside the block images in `<output-directory>/<document>/`.
 The options that describe a block are ignored: `echo` and its companions, `eval`, `include`, `label`, `cap`, `alt` as an option, `file`, `output-filename`, `pages`, `layout-ncol`, `align`, and `output-location`.
 
 Alt text is given as an attribute instead:

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -40,7 +40,7 @@ Set under `extensions.typst-render`.
 | `input` | | Key-value pairs passed as `--input`, readable through `sys.inputs`. |
 | `cache` | `true` | Cache compiled images between renders. |
 | `cache-refresh` | `false` | Remove stale cache files after each render. |
-| `output-directory` | | Where saved images are written. |
+| `output-directory` | `./assets/typst-render` | Where saved images are written, relative to the document. An empty string writes none, leaving them in the render cache where a deployed site cannot reach them. |
 | `output-source` | `false` | Also write the compiled Typst source beside each image. |
 
 : Options under `extensions.typst-render`. {.striped .hover tbl-colwidths="[22,12,66]"}
@@ -79,7 +79,8 @@ Everything in the second can be set globally as a default for every block, apart
 A red word `{typst} #text(red)[hello]` in a sentence.
 ```
 
-An inline expression takes the options that shape the compilation, `format`, `dpi`, `background`, `foreground`, `preamble`, `input`, `cache`, `output`, and `classes` among them.
+An inline expression takes the options that shape the compilation, `format`, `dpi`, `background`, `foreground`, `preamble`, `input`, `cache`, `output`, `classes`, `output-directory`, and `output-source` among them.
+Its image is written as `typst-inline-<N>.<ext>`, numbered in document order.
 The options that describe a block are ignored: `echo` and its companions, `eval`, `include`, `label`, `cap`, `alt` as an option, `file`, `output-filename`, `pages`, `layout-ncol`, `align`, and `output-location`.
 
 Alt text is given as an attribute instead:


### PR DESCRIPTION
Inline `{typst}` expressions were the only compiled unit never written outside the render cache, so a site referencing them shipped links into `.quarto/`, which Quarto does not copy to the output directory. They now go through the same save path as blocks, honouring `output-directory` and `output-source` under a `typst-inline-<N>` stem.

`output-directory` also defaults to `./assets/typst-render` rather than being unset, so images land somewhere a deployed site can serve without any configuration. Setting it to an empty string keeps them in the cache as before.

Turning that default on exposed a collision: labels and block counters are unique within a document only, so two documents in one directory both wrote `typst-block-1` and whichever rendered last overwrote the other, leaving one page pointing at the other figure. Images named from a label or a counter now go in a subdirectory of `output-directory` named after the document, as the render cache already does. An explicit `output-filename` still resolves directly against `output-directory`.

The documentation site drops its own `output-directory` override and uses the default, and generated image directories are gitignored.


The examples page also drops its `code-window` callout, since that interaction is only a matter of the order the extensions are registered in.
