### PR TITLE
feat: harmonise inline expressions with blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
 ### New Features
 
 - feat: inline `{typst}` expressions honour `output-directory` and `output-source`, writing `typst-inline-<N>` files alongside the images compiled from blocks.
+- feat: inline `{typst}` expressions accept the compilation options as attributes: `format`, `dpi`, `background`, `foreground`, `cache`, `classes`, `preamble`, and `input`, as in `` `{typst} $x$`{format="png" dpi="300"} ``.
+- feat: an inline expression with both a `light` and a `dark` colour is compiled for each mode in HTML output and emitted with Quarto's `light-content` and `dark-content` classes, as blocks already were.
+
+### Bug Fixes
+
+- fix: an inline expression with `output: asis` was emitted as raw Typst for every writer, so it vanished from HTML, LaTeX, and DOCX output. Only Typst output passes it through now; the others compile an image, as they do for a block.
+- fix: an inline expression with `output: asis` is scoped in `#[ ... ]` and gets the colour bindings, the `typst_define` values, and the `preamble` that blocks get. A `#let` or `#set` inside it no longer leaks into the rest of the document, and the preamble is finally in scope.
+- fix: inline expressions honour `eval` and `include`. `eval: false` leaves the expression as inline code, and `include: false` compiles and writes the image without embedding it.
+- fix: inline expressions warn about the PDF-to-PNG fallback in HTML output and about dual colours under `format: html`, and a failed compilation now leaves a `typst-render-error` marker in the text instead of the original code.
 
 ## 0.20.1 (2026-08-01)
 

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -561,8 +561,15 @@ local function resolve_preamble_entry(value)
     return nil
   end
   if value:match('%.typ$') then
+    -- Every block and every inline expression resolves the preamble, so the
+    -- file is read once per document through the shared cache rather than once
+    -- per unit. It is cleared for each document during the Meta pass.
     local file_path = paths.resolve_project_path(value)
-    local content = read_file(file_path)
+    local content = read_file_cache[file_path]
+    if content == nil then
+      content = read_file(file_path)
+      read_file_cache[file_path] = content or false
+    end
     if content then
       return content
     end
@@ -1463,6 +1470,39 @@ local function create_error_block(id)
   )
 end
 
+--- Resolve the image format to compile for, from the requested one and the
+--- output being written. Shared by blocks and inline expressions so the two
+--- cannot drift: `html` downgrades when it cannot be honoured, and `pdf` is
+--- unusable in HTML output.
+--- @param requested string|nil Format asked for by the options
+--- @return string Effective image format
+local function resolve_compile_format(requested)
+  local img_format = requested
+  if img_format and not VALID_FORMAT_SET[img_format] then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Invalid format "' .. img_format .. '"; auto-detecting from output format.'
+    )
+    img_format = nil
+  end
+  if not img_format then
+    img_format = get_image_format_for_output()
+  end
+
+  -- Native HTML output requires HTML-based output and Typst >= 0.15; otherwise
+  -- fall back to an image format with a warning.
+  img_format = resolve_html_format(img_format)
+
+  if img_format == 'pdf' and quarto.format.is_html_output() then
+    log.log_warning(
+      EXTENSION_NAME,
+      'PDF images are not supported in HTML output. Falling back to PNG.'
+    )
+    img_format = 'png'
+  end
+  return img_format
+end
+
 --- Create an inline error marker for failed Typst compilation.
 --- The inline counterpart of create_error_block; the expression it replaces is
 --- part of a sentence, so the marker has to be an inline element.
@@ -1928,31 +1968,7 @@ local function process_codeblock(el)
     return result
   end
 
-  -- Determine image format
-  local img_format = opts.format
-  if img_format and not VALID_FORMAT_SET[img_format] then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Invalid format "' .. img_format .. '"; auto-detecting from output format.'
-    )
-    img_format = nil
-  end
-  if not img_format then
-    img_format = get_image_format_for_output()
-  end
-
-  -- Native HTML output requires HTML-based output and Typst >= 0.15; otherwise
-  -- fall back to an image format with a warning.
-  img_format = resolve_html_format(img_format)
-
-  -- Warn about PDF in HTML
-  if img_format == 'pdf' and quarto.format.is_html_output() then
-    log.log_warning(
-      EXTENSION_NAME,
-      'PDF images are not supported in HTML output. Falling back to PNG.'
-    )
-    img_format = 'png'
-  end
+  local img_format = resolve_compile_format(opts.format)
 
   -- Dual-mode rendering for HTML/Reveal.js when both light and dark colours are present.
   -- Native HTML output renders once (colours apply via the Typst source, not CSS classes).
@@ -2280,9 +2296,11 @@ local function process_inline_code(el)
   end
 
   -- Nothing to compile: leave the expression as inline code, so the source
-  -- stays readable rather than vanishing from the sentence.
+  -- stays readable rather than vanishing from the sentence. With include off
+  -- there is nothing to show at all, as for a block that neither evaluates
+  -- nor echoes.
   if opts.eval == false then
-    return el
+    return do_include and el or {}
   end
 
   -- Native Typst output: pass through as a scoped RawInline. Any other writer
@@ -2304,46 +2322,7 @@ local function process_inline_code(el)
   opts.height = 'auto'
   opts.margin = '(x: 0.5pt, top: 0.5pt, bottom: 0.25em)'
 
-  local img_format = opts.format
-  if img_format and not VALID_FORMAT_SET[img_format] then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Invalid format "' .. img_format .. '"; auto-detecting from output format.'
-    )
-    img_format = nil
-  end
-  if not img_format then
-    img_format = get_image_format_for_output()
-  end
-  img_format = resolve_html_format(img_format)
-
-  if img_format == 'html' then
-    if has_dual_mode_colours(opts) then
-      log.log_warning(
-        EXTENSION_NAME,
-        'Dual light/dark colours are not supported with format "html"; using the document brand mode.'
-      )
-      opts = resolve_opts_colours(opts, global_brand_mode)
-    end
-    local html_source = build_typst_source(code, opts, false)
-    local body = compile_typst_html(html_source, opts)
-    if not body then
-      log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
-      return create_error_inline(inline_id)
-    end
-    if not do_include then
-      return {}
-    end
-    return create_inline_html_element(typst_cli.strip_paragraph(body), opts)
-  end
-
-  if img_format == 'pdf' and quarto.format.is_html_output() then
-    log.log_warning(
-      EXTENSION_NAME,
-      'PDF images are not supported in HTML output. Falling back to PNG.'
-    )
-    img_format = 'png'
-  end
+  local img_format = resolve_compile_format(opts.format)
 
   --- Compile one colour mode and build its inline element.
   --- Inline expressions carry no label or output-filename, so the image is named
@@ -2375,19 +2354,24 @@ local function process_inline_code(el)
     return create_inline_image_element(img_path, mode_opts)
   end
 
-  -- Dual-mode rendering for HTML when both light and dark colours are present.
-  -- Quarto's own `light-content` / `dark-content` classes hide the mode that
-  -- does not match the page, and work on inline elements too.
-  if quarto.format.is_html_output() and has_dual_mode_colours(opts) then
+  local element
+  if img_format == 'html' then
+    if has_dual_mode_colours(opts) then
+      log.log_warning(
+        EXTENSION_NAME,
+        'Dual light/dark colours are not supported with format "html"; using the document brand mode.'
+      )
+      opts = resolve_opts_colours(opts, global_brand_mode)
+    end
+    local html_source = build_typst_source(code, opts, false)
+    local body = compile_typst_html(html_source, opts)
+    element = body and create_inline_html_element(typst_cli.strip_paragraph(body), opts) or nil
+  elseif quarto.format.is_html_output() and has_dual_mode_colours(opts) then
+    -- Dual-mode rendering when both light and dark colours are present. Quarto's
+    -- own `light-content` / `dark-content` classes hide the mode that does not
+    -- match the page, and work on inline elements too.
     local light = compile_inline(resolve_opts_colours(opts, 'light'), '-light')
     local dark = compile_inline(resolve_opts_colours(opts, 'dark'), '-dark')
-    if not light and not dark then
-      log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
-      return create_error_inline(inline_id)
-    end
-    if not do_include then
-      return {}
-    end
     local inlines = {}
     if light then
       inlines[#inlines + 1] = pandoc.Span({ light }, pandoc.Attr('', { 'light-content' }, {}))
@@ -2395,13 +2379,16 @@ local function process_inline_code(el)
     if dark then
       inlines[#inlines + 1] = pandoc.Span({ dark }, pandoc.Attr('', { 'dark-content' }, {}))
     end
-    return pandoc.Inlines(inlines)
+    element = #inlines > 0 and pandoc.Inlines(inlines) or nil
+  else
+    local resolved_opts = has_dual_mode_colours(opts)
+        and resolve_opts_colours(opts, global_brand_mode)
+        or opts
+    element = compile_inline(resolved_opts, nil)
   end
 
-  local resolved_opts = has_dual_mode_colours(opts)
-      and resolve_opts_colours(opts, global_brand_mode)
-      or opts
-  local element = compile_inline(resolved_opts, nil)
+  -- Compilation and file-save side effects have run; report a failure once,
+  -- then suppress embedding if include is false.
   if not element then
     log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
     return create_error_inline(inline_id)

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -803,6 +803,30 @@ local function build_typst_source(code, opts, include_page)
   return table.concat(parts, '\n')
 end
 
+--- Build the inner Typst source for `output: asis` pass-through.
+--- Unlike build_typst_source there is no `#set page(...)`: the code is emitted
+--- into the document Typst is already laying out, so it inherits the page.
+--- @param code string User Typst code
+--- @param opts table Merged options (colours must be plain strings)
+--- @return string Typst source to place inside a `#[ ... ]` scope
+local function build_asis_inner(code, opts)
+  local parts = {}
+  inject_colour_vars(parts, opts)
+  local define_preamble = build_define_preamble()
+  if define_preamble then
+    parts[#parts + 1] = define_preamble
+  end
+  if opts.foreground then
+    parts[#parts + 1] = '#set text(fill: ' .. opts.foreground .. ')'
+  end
+  local preamble = resolve_preamble(opts.preamble)
+  if preamble then
+    parts[#parts + 1] = preamble
+  end
+  parts[#parts + 1] = code
+  return table.concat(parts, '\n')
+end
+
 --- Build a human-readable cache file stem from label or block number and a
 --- content hash.  Returns e.g. "typst-fig-my-diagram-a1b2c3d4" or "typst-block-3-a1b2c3d4".
 --- @param source string Full Typst source
@@ -1439,6 +1463,18 @@ local function create_error_block(id)
   )
 end
 
+--- Create an inline error marker for failed Typst compilation.
+--- The inline counterpart of create_error_block; the expression it replaces is
+--- part of a sentence, so the marker has to be an inline element.
+--- @param id string Inline identifier (e.g. typst-inline-2)
+--- @return pandoc.Span Error span
+local function create_error_inline(id)
+  return pandoc.Span(
+    { pandoc.Strong({ pandoc.Str('[typst-render] ' .. compilation_failed_message(id)) }) },
+    pandoc.Attr('', { 'typst-render-error' }, {})
+  )
+end
+
 --- Compile Typst code and produce a result block (image element with alignment).
 --- @param code string User Typst code
 --- @param opts table Resolved options (colours must be plain strings)
@@ -1867,21 +1903,7 @@ local function process_codeblock(el)
     local typst_opts = has_dual_mode_colours(opts)
         and resolve_opts_colours(opts, global_brand_mode)
         or opts
-    local preamble = resolve_preamble(typst_opts.preamble)
-    local parts = {}
-    inject_colour_vars(parts, typst_opts)
-    local define_preamble = build_define_preamble()
-    if define_preamble then
-      parts[#parts + 1] = define_preamble
-    end
-    if typst_opts.foreground then
-      parts[#parts + 1] = '#set text(fill: ' .. typst_opts.foreground .. ')'
-    end
-    if preamble then
-      parts[#parts + 1] = preamble
-    end
-    parts[#parts + 1] = code
-    local inner = table.concat(parts, '\n')
+    local inner = build_asis_inner(code, typst_opts)
     local scoped_code
     if has_custom_block_options(typst_opts) then
       local params = { 'width: 100%' }
@@ -2145,6 +2167,72 @@ local function create_inline_image_element(img_path, opts)
   )
 end
 
+--- Attributes accepted on an inline `{typst}` element, beyond `alt`.
+--- Only options that shape the compilation: everything describing a block
+--- (label, caption, echo, pages, layout, alignment) stays a block option.
+local INLINE_ATTRIBUTES = {
+  'format', 'dpi', 'background', 'foreground', 'cache', 'classes', 'preamble', 'input',
+}
+
+--- Fold the accepted attributes of an inline Code element into merged options.
+--- Values arrive as strings, so `cache` is mapped to a boolean and the colours
+--- go through the same resolution as a per-block override.
+--- @param attrs table|nil Element attributes
+--- @param opts table Merged options, modified in place
+local function apply_inline_attributes(attrs, opts)
+  if not attrs then
+    return
+  end
+  for _, key in ipairs(INLINE_ATTRIBUTES) do
+    local value = attrs[key]
+    if type(value) == 'string' and value ~= '' then
+      if key == 'cache' then
+        opts.cache = value ~= 'false'
+      elseif key == 'input' then
+        opts._block_input = value
+      elseif key == 'background' or key == 'foreground' then
+        -- `auto` reads _brand.yml and may resolve to nothing, so the branches
+        -- stay explicit: an `x and y or z` chain would fall through to the
+        -- literal "auto" when both the brand colour and the default are nil.
+        if value == 'auto' then
+          opts[key] = resolve_colour_config('auto', key) or DEFAULTS[key]
+        else
+          opts[key] = css_colour_to_typst(value)
+        end
+      else
+        opts[key] = value
+      end
+    end
+  end
+end
+
+--- Build the `output: asis` pass-through for an inline expression.
+--- Scoped in `#[ ... ]` so that `#let` and `#set` inside stay local, as they do
+--- for a block. No newline pads the scope: Typst swallows the break after a
+--- code statement but renders one after `#[` as a space in the sentence.
+--- @param code string User Typst code
+--- @param opts table Merged options (colours must be plain strings)
+--- @return pandoc.RawInline Raw Typst inline
+local function create_inline_asis_element(code, opts)
+  -- A blank line inside inline content starts a paragraph; the preamble is the
+  -- one part that can carry them, so runs of newlines collapse to one.
+  local inner = (build_asis_inner(code, opts):gsub('\n%s*\n+', '\n'))
+  local scoped = '#[' .. inner .. ']'
+  if has_custom_block_options(opts) then
+    local params = {}
+    if opts.margin ~= DEFAULTS.margin then
+      params[#params + 1] = 'inset: ' .. opts.margin
+    end
+    if opts.background ~= DEFAULTS.background then
+      params[#params + 1] = 'fill: ' .. opts.background
+    end
+    if #params > 0 then
+      scoped = '#box(' .. table.concat(params, ', ') .. ')[' .. scoped .. ']'
+    end
+  end
+  return pandoc.RawInline('typst', scoped)
+end
+
 --- Process a {typst} inline Code element.
 --- Compiles inline Typst expressions to tightly-cropped images.
 --- @param el pandoc.Code
@@ -2178,78 +2266,150 @@ local function process_inline_code(el)
   end
 
   local opts = cell.merge_options({}, global_config, DEFAULTS)
-  opts.width = 'auto'
-  opts.height = 'auto'
-  opts.margin = '(x: 0.5pt, top: 0.5pt, bottom: 0.25em)'
   opts._inline = true
   opts._alt = (el.attributes and el.attributes['alt'] and el.attributes['alt'] ~= '')
       and el.attributes['alt']
       or code
+  apply_inline_attributes(el.attributes, opts)
 
-  -- Resolve table-valued colours to strings (inline can't do dual-mode rendering)
-  if has_dual_mode_colours(opts) then
-    opts = resolve_opts_colours(opts, global_brand_mode)
-  end
-
+  local do_include = cell.should_include(opts)
   local output_mode = cell.resolve_output_mode(opts)
 
   if output_mode == 'false' then
     return {}
   end
 
-  if output_mode == 'asis' then
-    return pandoc.RawInline('typst', code)
+  -- Nothing to compile: leave the expression as inline code, so the source
+  -- stays readable rather than vanishing from the sentence.
+  if opts.eval == false then
+    return el
   end
+
+  -- Native Typst output: pass through as a scoped RawInline. Any other writer
+  -- drops raw Typst, so those fall through and compile an image, as blocks do.
+  if output_mode == 'asis' and quarto.format.is_typst_output() then
+    if not do_include then
+      return {}
+    end
+    local typst_opts = has_dual_mode_colours(opts)
+        and resolve_opts_colours(opts, global_brand_mode)
+        or opts
+    return create_inline_asis_element(code, typst_opts)
+  end
+
+  -- Geometry for the compiled image: a page just big enough for the expression,
+  -- sitting on the text baseline. Set after the pass-through, which uses the
+  -- configured margin instead.
+  opts.width = 'auto'
+  opts.height = 'auto'
+  opts.margin = '(x: 0.5pt, top: 0.5pt, bottom: 0.25em)'
 
   local img_format = opts.format
   if img_format and not VALID_FORMAT_SET[img_format] then
-    log.log_warning(EXTENSION_NAME, 'Invalid inline format "' .. img_format .. '"; auto-detecting.')
+    log.log_warning(
+      EXTENSION_NAME,
+      'Invalid format "' .. img_format .. '"; auto-detecting from output format.'
+    )
     img_format = nil
   end
   if not img_format then
     img_format = get_image_format_for_output()
   end
   img_format = resolve_html_format(img_format)
+
   if img_format == 'html' then
+    if has_dual_mode_colours(opts) then
+      log.log_warning(
+        EXTENSION_NAME,
+        'Dual light/dark colours are not supported with format "html"; using the document brand mode.'
+      )
+      opts = resolve_opts_colours(opts, global_brand_mode)
+    end
     local html_source = build_typst_source(code, opts, false)
     local body = compile_typst_html(html_source, opts)
     if not body then
       log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
-      return el
+      return create_error_inline(inline_id)
+    end
+    if not do_include then
+      return {}
     end
     return create_inline_html_element(typst_cli.strip_paragraph(body), opts)
   end
+
   if img_format == 'pdf' and quarto.format.is_html_output() then
+    log.log_warning(
+      EXTENSION_NAME,
+      'PDF images are not supported in HTML output. Falling back to PNG.'
+    )
     img_format = 'png'
   end
 
-  local full_source = build_typst_source(code, opts)
-  local pages = compile_typst(full_source, opts, img_format)
+  --- Compile one colour mode and build its inline element.
+  --- Inline expressions carry no label or output-filename, so the image is named
+  --- from the inline counter. A failed copy falls back to the cache path so the
+  --- render still produces an image.
+  --- @param mode_opts table Options with colours resolved to strings
+  --- @param mode_suffix string|nil "-light", "-dark", or nil
+  --- @return pandoc.Inline|nil
+  local function compile_inline(mode_opts, mode_suffix)
+    local source = build_typst_source(code, mode_opts)
+    local pages = compile_typst(source, mode_opts, img_format)
+    if not pages or #pages == 0 then
+      return nil
+    end
+    local img_path = pages[1]
+    local output_path = resolve_output_path(
+      global_config['output-directory'], mode_opts['output-directory'],
+      nil, nil, inline_id, img_format
+    )
+    if output_path then
+      local out_pages = save_output_files({ img_path }, output_path, mode_suffix, img_format)
+      if out_pages then
+        img_path = out_pages[1]
+      end
+      if mode_opts['output-source'] == true then
+        save_source_file(source, output_path, mode_suffix)
+      end
+    end
+    return create_inline_image_element(img_path, mode_opts)
+  end
 
-  if not pages or #pages == 0 then
+  -- Dual-mode rendering for HTML when both light and dark colours are present.
+  -- Quarto's own `light-content` / `dark-content` classes hide the mode that
+  -- does not match the page, and work on inline elements too.
+  if quarto.format.is_html_output() and has_dual_mode_colours(opts) then
+    local light = compile_inline(resolve_opts_colours(opts, 'light'), '-light')
+    local dark = compile_inline(resolve_opts_colours(opts, 'dark'), '-dark')
+    if not light and not dark then
+      log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
+      return create_error_inline(inline_id)
+    end
+    if not do_include then
+      return {}
+    end
+    local inlines = {}
+    if light then
+      inlines[#inlines + 1] = pandoc.Span({ light }, pandoc.Attr('', { 'light-content' }, {}))
+    end
+    if dark then
+      inlines[#inlines + 1] = pandoc.Span({ dark }, pandoc.Attr('', { 'dark-content' }, {}))
+    end
+    return pandoc.Inlines(inlines)
+  end
+
+  local resolved_opts = has_dual_mode_colours(opts)
+      and resolve_opts_colours(opts, global_brand_mode)
+      or opts
+  local element = compile_inline(resolved_opts, nil)
+  if not element then
     log.log_warning(EXTENSION_NAME, compilation_failed_message(inline_id))
-    return el
+    return create_error_inline(inline_id)
   end
-
-  -- Inline expressions carry no label or output-filename, so the image is named
-  -- from the inline counter. A failed copy falls back to the cache path so the
-  -- render still produces an image.
-  local img_path = pages[1]
-  local output_path = resolve_output_path(
-    global_config['output-directory'], opts['output-directory'],
-    nil, nil, inline_id, img_format
-  )
-  if output_path then
-    local out_pages = save_output_files({ img_path }, output_path, nil, img_format)
-    if out_pages then
-      img_path = out_pages[1]
-    end
-    if opts['output-source'] == true then
-      save_source_file(full_source, output_path, nil)
-    end
+  if not do_include then
+    return {}
   end
-
-  return create_inline_image_element(img_path, opts)
+  return element
 end
 
 --- Remove stale cache files after all blocks have been processed.

--- a/docs/_extensions/mcanouil/atelier/_extension.yml
+++ b/docs/_extensions/mcanouil/atelier/_extension.yml
@@ -1,59 +1,20 @@
 title: Atelier
 author: Mickaël Canouil
 version: 0.10.2
-quarto-required: ">=1.9.36"
+quarto-required: '>=1.9.36'
+source: mcanouil/quarto-atelier@0.10.2
+source-type: registry
 contributes:
-  project:
-    project:
-      type: website
-      output-dir: _site
-    website:
-      repo-actions: [edit, issue]
-      repo-link-target: _blank
-      repo-link-rel: noopener noreferrer
-      # `locale` matches `lang: en-GB` below; override the two together.
-      # Naming `twitter-card` at all is what switches Quarto's Twitter
-      # provider on, after which it inherits title, description, image, and
-      # image alt from each page.
-      open-graph:
-        locale: en_GB
-      twitter-card:
-        card-style: summary_large_image
-      page-navigation: true
-      back-to-top-navigation: true
-      llms-txt: true
-      search:
-        location: navbar
-        type: overlay
-      # `background` and `foreground` are left to the theme on both bars: the
-      # chrome palette in `html/chrome.scss` sets `$navbar-bg`, `$navbar-fg`,
-      # `$footer-bg`, and `$footer-fg` from a layer Quarto evaluates first, so
-      # naming them here would be a configuration with no effect.
-      navbar:
-        search: true
-      page-footer:
-        border: true
-        left: |
-          Powered by [Quarto](https://quarto.org){target="_blank" rel="noopener noreferrer"}.
-        center: |
-          &copy; []{#current-year} [Mickaël CANOUIL](https://mickael.canouil.fr){target="_blank" rel="noopener noreferrer"}.
-    format: atelier-html
   formats:
     common:
       lang: en-GB
-      date-format: "dddd[, the] Do [of] MMMM, YYYY"
+      date-format: dddd[, the] Do [of] MMMM, YYYY
       code-copy: true
       code-overflow: wrap
       code-link: false
     html:
       respect-user-color-scheme: true
-      # Quarto builds the canonical link from `website.site-url`, giving a
-      # directory index the URL of its directory. Set `canonical-url: false`
-      # on a page served from more than one URL, such as `404.qmd`.
       canonical-url: true
-      # `html/chrome.scss` comes before `brand` on purpose: Quarto evaluates
-      # user layer defaults in reverse list order, so a file placed first is
-      # evaluated last, after the brand palette it derives the chrome from.
       theme:
         light:
           - html/chrome.scss
@@ -84,4 +45,33 @@ contributes:
         - file: html/scripts/ordinal-dates.html
         - file: html/scripts/a11y-fixes.html
         - file: html/scripts/navbar-tooltips.html
-source: mcanouil/quarto-atelier@0.10.2
+  project:
+    project:
+      type: website
+      output-dir: _site
+    website:
+      repo-actions:
+        - edit
+        - issue
+      repo-link-target: _blank
+      repo-link-rel: noopener noreferrer
+      open-graph:
+        locale: en_GB
+      twitter-card:
+        card-style: summary_large_image
+      page-navigation: true
+      back-to-top-navigation: true
+      llms-txt: true
+      search:
+        location: navbar
+        type: overlay
+      navbar:
+        search: true
+      page-footer:
+        border: true
+        left: |
+          Powered by [Quarto](https://quarto.org){target="_blank" rel="noopener noreferrer"}.
+        center: >
+          &copy; []{#current-year} [Mickaël CANOUIL](https://mickael.canouil.fr){target="_blank" rel="noopener
+          noreferrer"}.
+    format: atelier-html

--- a/docs/_extensions/mcanouil/code-window/_extension.yml
+++ b/docs/_extensions/mcanouil/code-window/_extension.yml
@@ -1,11 +1,12 @@
 title: Code Window
 author: Mickaël Canouil
-version: 1.3.1
-quarto-required: ">=1.9.36"
+version: 1.3.3
+quarto-required: '>=1.9.36'
+source: mcanouil/quarto-code-window@1.3.3
+source-type: registry
 contributes:
   filters:
     - at: pre-quarto
       path: main.lua
     - at: post-quarto
       path: _modules/hotfix/typst-title-fix.lua
-source: mcanouil/quarto-code-window@1.3.1

--- a/docs/_extensions/mcanouil/code-window/_schema.yml
+++ b/docs/_extensions/mcanouil/code-window/_schema.yml
@@ -1,4 +1,4 @@
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   enabled:

--- a/docs/_extensions/mcanouil/gitlink/_extension.yml
+++ b/docs/_extensions/mcanouil/gitlink/_extension.yml
@@ -1,8 +1,10 @@
 title: gitlink
 author: Mickaël Canouil
-version: 1.9.2
-quarto-required: ">=1.8.21"
+version: 1.10.0
+quarto-required: '>=1.9.38'
+source: mcanouil/quarto-gitlink@1.10.0
+source-type: registry
 contributes:
   filters:
-    - gitlink.lua
-source: mcanouil/quarto-gitlink@1.9.2
+    - path: gitlink.lua
+      at: post-quarto

--- a/docs/_extensions/mcanouil/iconify/_extension.yml
+++ b/docs/_extensions/mcanouil/iconify/_extension.yml
@@ -1,10 +1,11 @@
 title: Iconify
 author: Mickaël Canouil
 version: 4.0.1
-quarto-required: ">=1.5.57"
+quarto-required: '>=1.5.57'
+source: mcanouil/quarto-iconify@4.0.1
+source-type: registry
 contributes:
-  shortcodes:
-    - iconify.lua
   filters:
     - iconify-filter.lua
-source: mcanouil/quarto-iconify@4.0.1
+  shortcodes:
+    - iconify.lua

--- a/docs/_extensions/mcanouil/pastel/_extension.yml
+++ b/docs/_extensions/mcanouil/pastel/_extension.yml
@@ -1,11 +1,10 @@
 title: Pastel
 author: Mickaël Canouil
 version: 0.1.1
-# The Quarto version the brand and its stylesheet are developed and verified
-# against. quarto-atelier, which these sites are built on, requires >=1.9.36.
-quarto-required: ">=1.10.18"
+quarto-required: '>=1.10.18'
+source: mcanouil/quarto-pastel@0.1.1
+source-type: registry
 contributes:
   metadata:
     project:
       brand: brand.yml
-source: mcanouil/quarto-pastel@0.1.1

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -79,11 +79,23 @@ Everything in the second can be set globally as a default for every block, apart
 A red word `{typst} #text(red)[hello]` in a sentence.
 ```
 
-An inline expression takes the options that shape the compilation, `format`, `dpi`, `background`, `foreground`, `preamble`, `input`, `cache`, `output`, `classes`, `output-directory`, and `output-source` among them.
+An inline expression takes the global options that shape the compilation, `format`, `dpi`, `background`, `foreground`, `preamble`, `input`, `cache`, `output`, `eval`, `include`, `classes`, `output-directory`, and `output-source` among them.
 Its image is written as `typst-inline-<N>.<ext>`, numbered in document order, beside the block images in `<output-directory>/<document>/`.
-The options that describe a block are ignored: `echo` and its companions, `eval`, `include`, `label`, `cap`, `alt` as an option, `file`, `output-filename`, `pages`, `layout-ncol`, `align`, and `output-location`.
+The options that describe a block are ignored: `echo` and its companions, `label`, `cap`, `file`, `output-filename`, `pages`, `layout-ncol`, `align`, and `output-location`.
 
-Alt text is given as an attribute instead:
+`eval: false` leaves the expression as inline code, since there is no source listing to fall back on.
+`include: false` compiles and writes the image, then leaves the expression out of the sentence.
+
+The compilation options can also be set on one expression, as attributes:
+
+```markdown
+A big red `{typst} $pi r^2$`{format="png" dpi="300" foreground="#ff0000"} in a sentence.
+```
+
+`format`, `dpi`, `background`, `foreground`, `cache`, `classes`, `preamble`, and `input` are accepted there, along with `alt`.
+Anything else is ignored; where images are written stays a global decision.
+
+Alt text is given the same way:
 
 ```markdown
 The area is `{typst} $pi r^2$`{alt="pi r squared"}.
@@ -92,6 +104,10 @@ The area is `{typst} $pi r^2$`{alt="pi r squared"}.
 Without it, the Typst source is used as the alt text.
 
 An inline expression sets its own `width`, `height`, and `margin` so the result sits on the text baseline, and ignores the values configured for blocks.
+With `output: asis` in Typst output it is passed through instead, scoped in `#[ ... ]` with the preamble and colour bindings ahead of it, so a `#let` or `#set` inside stays local to the expression.
+Every other writer compiles an image, as it does for a block.
+
+When `background` or `foreground` carries both a `light` and a `dark` value, an expression in HTML output is compiled twice and both images are emitted, marked with Quarto's `light-content` and `dark-content` so the page shows the one matching its mode.
 
 ## Interactions
 


### PR DESCRIPTION
Inline `{typst}` expressions had drifted from the block path and read only a subset of the configuration. Reading the two side by side turned up six differences, two of which produced wrong output.

`output: asis` returned raw Typst for every writer, so with it set globally an inline expression vanished from HTML, LaTeX, and DOCX. Only Typst output passes it through now, and every other writer compiles an image, as it already did for a block. That pass-through also emitted the user code alone, without the colour bindings, the `typst_define` values, or the `preamble` a block gets, and unscoped, so a `#let` or `#set` inside leaked into the rest of the document. Both paths now share one source builder and the inline form is wrapped in `#[ ... ]`, built without padding newlines since Typst renders those as spaces in the sentence.

`eval` and `include` are honoured: `eval: false` leaves the expression as inline code, and `include: false` writes the image without embedding it. The compilation options can now be set on a single expression as attributes, as in `` `{typst} $x$`{format="png" dpi="300"} ``, covering `format`, `dpi`, `background`, `foreground`, `cache`, `classes`, `preamble`, and `input`; where images are written stays a global decision. An expression carrying both a `light` and a `dark` colour is compiled for each mode in HTML output and emitted with Quarto's `light-content` and `dark-content` classes, which work on inline elements as Quarto's own brand logo shortcode shows.

The warnings blocks emit for the PDF-to-PNG fallback and for dual colours under `format: html` are emitted for inline too, and a failed compilation leaves a `typst-render-error` marker in the text instead of the original code.