### PR TITLE
feat: expose the document brand to Typst blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### New Features
 
-- feat: the document brand is bound inside every block and inline expression as `_typst_render_brand`, a dictionary in `_brand.yml` shape holding the nine semantic colour roles and the `base` and `headings` font families. It follows `brand-mode` and the side being compiled, and is empty when the document has no brand.
+- feat: the document brand is bound inside every block and inline expression as `_typst_render_brand`, a dictionary in `_brand.yml` shape holding the nine semantic colour roles and the `base` and `headings` font families.
+  It follows `brand-mode` and the side being compiled, and is empty when the document has no brand.
+  Every cached image is compiled again on the first render after this change, because the binding is part of the source that the cache key is built from.
 
 ## 0.21.0 (2026-08-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Features
 
 - feat: the document brand is bound inside every block and inline expression as `_typst_render_brand`, a dictionary in `_brand.yml` shape holding the nine semantic colour roles and the `base` and `headings` font families.
-  It follows `brand-mode` and the side being compiled, and is empty when the document has no brand.
+  It follows `brand-mode` and the side being compiled, and its `color` and `typography` keys are empty when the document has no brand.
   Every cached image is compiled again on the first render after this change, because the binding is part of the source that the cache key is built from.
 
 ## 0.21.0 (2026-08-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- feat: the document brand is bound inside every block and inline expression as `_typst_render_brand`, a dictionary in `_brand.yml` shape holding the nine semantic colour roles and the `base` and `headings` font families. It follows `brand-mode` and the side being compiled, and is empty when the document has no brand.
+
 ## 0.21.0 (2026-08-02)
 
 ### Breaking Changes

--- a/_extensions/typst-render/_modules/code-cell.lua
+++ b/_extensions/typst-render/_modules/code-cell.lua
@@ -1,5 +1,5 @@
 --- Code Cell - Generic code-cell processing for Quarto Lua extensions
---- @module code-cell
+--- @module "code-cell"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/typst-render/_modules/logging.lua
+++ b/_extensions/typst-render/_modules/logging.lua
@@ -1,5 +1,5 @@
 --- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
---- @module logging
+--- @module "logging"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/typst-render/_modules/paths.lua
+++ b/_extensions/typst-render/_modules/paths.lua
@@ -1,5 +1,5 @@
 --- MC Paths - Path resolution utilities for Quarto Lua filters and shortcodes
---- @module paths
+--- @module "paths"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/typst-render/_modules/string.lua
+++ b/_extensions/typst-render/_modules/string.lua
@@ -1,5 +1,5 @@
 --- MC String - String manipulation and escaping for Quarto Lua filters and shortcodes
---- @module string
+--- @module "string"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/typst-render/_modules/typst-cli.lua
+++ b/_extensions/typst-render/_modules/typst-cli.lua
@@ -1,5 +1,5 @@
 --- MC Typst CLI - Typst binary discovery, version detection, and HTML extraction
---- @module typst-cli
+--- @module "typst-cli"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -274,6 +274,9 @@ end
 --- Cached brand module (nil = not yet attempted, false = unavailable)
 local brand_module = nil
 
+--- Memoised `_typst_render_brand` literals, keyed by brand mode.
+local brand_literal_cache = {}
+
 --- Load the Quarto brand module if available.
 --- @return table|nil The brand module, or nil if unavailable
 local function get_brand_module()
@@ -312,6 +315,118 @@ local function css_colour_to_typst(css_colour)
     return 'rgb("' .. css_colour .. '")'
   end
   return css_colour
+end
+
+--- Semantic brand colour roles carried by `_typst_render_brand`, in brand.yml order.
+--- These are the roles a Typst theme can act on: ink, paper, and the discrete
+--- data palette. Palette entries and logos stay out.
+local BRAND_COLOUR_ROLES = {
+  'foreground', 'background', 'primary', 'secondary', 'tertiary',
+  'success', 'info', 'warning', 'danger',
+}
+
+--- Brand typography entries carried by `_typst_render_brand`.
+--- Only the family survives: Typst can use a font family only when the compiler
+--- already has it, and brand sizes are relative units with no pt equivalent.
+local BRAND_TYPOGRAPHY_ENTRIES = { 'base', 'headings' }
+
+--- Normalise a CSS colour to a brand.yml hex string.
+--- The brand dictionary carries brand.yml *values*, not Typst expressions, so a
+--- consumer reads them the same way it reads the file itself. Such a consumer
+--- takes hex only, and would read a CSS keyword as a palette entry name.
+--- @param css string CSS colour string from the brand module
+--- @return string|nil "#rgb", "#rgba", "#rrggbb", or "#rrggbbaa", else nil
+local function brand_colour_to_hex(css)
+  if type(css) ~= 'string' then return nil end
+  local digits = css:match('^#(%x+)$')
+  if digits then
+    local count = #digits
+    if count == 3 or count == 4 or count == 6 or count == 8 then return css end
+    return nil
+  end
+  local args = css:match('^rgba?%((.+)%)$')
+  if not args then return nil end
+  local components = {}
+  for part in args:gmatch('[^,%s/]+') do components[#components + 1] = part end
+  if #components < 3 then return nil end
+  local out = { '#' }
+  for index = 1, 3 do
+    local percent = components[index]:match('^(%d+%.?%d*)%%$')
+    local value = percent and (tonumber(percent) * 255 / 100) or tonumber(components[index])
+    if not value then return nil end
+    value = math.min(math.max(value, 0), 255)
+    out[#out + 1] = string.format('%02X', math.floor(value + 0.5))
+  end
+  return table.concat(out)
+end
+
+--- Build the brand dictionary for one mode, in brand.yml shape.
+--- Quarto's brand module has already followed palette aliases and light/dark
+--- variants, so a downstream resolver has nothing left to do.
+--- @param mode string "light" or "dark"
+--- @return table|nil Table with `color` and `typography` keys, or nil when empty
+local function build_brand_dict(mode)
+  local brand = get_brand_module()
+  if not brand or not brand.get_color_css then return nil end
+
+  local resolved_mode = mode
+  if brand.has_mode then
+    local ok, present = pcall(brand.has_mode, mode)
+    if ok and not present then
+      local other = mode == 'light' and 'dark' or 'light'
+      local ok_other, present_other = pcall(brand.has_mode, other)
+      if not (ok_other and present_other) then return nil end
+      resolved_mode = other
+    end
+  end
+
+  local colours = {}
+  for _, role in ipairs(BRAND_COLOUR_ROLES) do
+    local ok, css = pcall(brand.get_color_css, resolved_mode, role)
+    if ok and type(css) == 'string' and css ~= '' then
+      local hex = brand_colour_to_hex(css)
+      if hex then
+        colours[role] = hex
+      else
+        log.log_warning(
+          EXTENSION_NAME,
+          'Brand colour "' .. role .. '" is "' .. css .. '", which is not a hex value; '
+          .. 'omitting it from _typst_render_brand.'
+        )
+      end
+    end
+  end
+
+  local typography = {}
+  if brand.get_typography then
+    for _, name in ipairs(BRAND_TYPOGRAPHY_ENTRIES) do
+      local ok, font = pcall(brand.get_typography, resolved_mode, name)
+      if ok and font then
+        local family = type(font) == 'table' and font.family or font
+        if type(family) == 'string' and family ~= '' then
+          typography[name] = { family = family }
+        end
+      end
+    end
+  end
+
+  local dict = {}
+  if next(colours) ~= nil then dict.color = colours end
+  if next(typography) ~= nil then dict.typography = typography end
+  if next(dict) == nil then return nil end
+  return dict
+end
+
+--- Return the `_typst_render_brand` Typst literal for a mode, memoised per render.
+--- @param mode string "light" or "dark"
+--- @return string Typst dictionary literal, `(:)` when the document has no brand
+local function brand_literal(mode)
+  local cached = brand_literal_cache[mode]
+  if cached then return cached end
+  local dict = build_brand_dict(mode)
+  local literal = dict and to_typst_literal(dict) or '(:)'
+  brand_literal_cache[mode] = literal
+  return literal
 end
 
 --- Resolve a colour option to a config value preserving both modes when available.
@@ -728,6 +843,9 @@ end
 
 --- Resolve table-valued colours in opts to strings for a specific mode.
 --- Returns a shallow copy of opts with background/foreground as plain strings.
+--- Records the mode so the brand dictionary is built for the same side of the
+--- pair; paths that never split keep `_brand_mode` unset and fall back to the
+--- document-wide mode.
 --- @param opts table Merged options (may contain table-valued colours)
 --- @param mode string "light" or "dark"
 --- @return table Copy of opts with colours resolved to strings
@@ -738,6 +856,7 @@ local function resolve_opts_colours(opts, mode)
   end
   resolved.background = resolve_colour_value(opts.background, mode) or DEFAULTS.background
   resolved.foreground = resolve_colour_value(opts.foreground, mode)
+  resolved._brand_mode = mode
   return resolved
 end
 
@@ -750,10 +869,14 @@ local function typst_colour_to_hex(typst_expr)
   return typst_expr:match('^rgb%("(#[%x]+)"%)$')
 end
 
---- Prepend Typst let-bindings for the render background/foreground variables.
---- These make document colours available to library code under predictable names.
+--- Prepend Typst let-bindings for the render background/foreground variables and
+--- the document brand dictionary.
+--- These make document colours and brand data available to library code under
+--- predictable names. The brand dictionary is always bound, empty when the
+--- document has no brand, so consuming code compiles either way.
 --- @param parts table String parts list to append to
---- @param opts table Options containing background and optional foreground
+--- @param opts table Options containing background, optional foreground, and
+---   optionally `_brand_mode` when compiling one side of a light/dark pair
 local function inject_colour_vars(parts, opts)
   parts[#parts + 1] = '#let _typst_render_background = ' .. opts.background
   if opts.foreground then
@@ -761,6 +884,8 @@ local function inject_colour_vars(parts, opts)
   else
     parts[#parts + 1] = '#let _typst_render_foreground = none'
   end
+  parts[#parts + 1] = '#let _typst_render_brand = '
+      .. brand_literal(opts._brand_mode or global_brand_mode)
 end
 
 --- Build the `#set page(...)` directive from options (for image compilation).
@@ -1620,6 +1745,9 @@ end
 local function get_configuration(meta)
   register_custom_crossref_types(meta)
   read_file_cache = {}
+  -- Quarto reuses the Lua state across documents in a project render, so a brand
+  -- literal built for one document must not leak into the next.
+  brand_literal_cache = {}
   -- Quarto may reuse the Lua state across documents; re-inject the Typst head
   -- CSS for each document that produces native HTML output.
   typst_cli.reset_head_injection()

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -66,15 +66,13 @@ local DEFAULTS = {
 --- Keys consumed by the filter; any other option is forwarded as an HTML attribute.
 --- NOTE: pairs(DEFAULTS) skips nil-valued keys, so all keys with nil defaults
 --- must be listed explicitly here to prevent them leaking as HTML attributes.
+--- Keys the filter sets on itself are not listed: `is_known_key` claims every
+--- name starting with an underscore.
 local KNOWN_KEYS = {
   cap = true,
   alt = true,
   ['code-summary'] = true,
   ['code-line-numbers'] = true,
-  _block_input = true,
-  _inline = true,
-  _alt = true,
-  _source = true,
   root = true,
   ['font-path'] = true,
   ['package-path'] = true,
@@ -97,10 +95,17 @@ for k in pairs(DEFAULTS) do
 end
 
 --- Check whether a key is consumed by the filter (not forwarded as an attribute).
---- Matches exact known keys and prefix-specific cross-ref keys (e.g. fig-cap, tbl-alt).
+--- Matches keys the filter sets on itself (leading underscore), exact known keys,
+--- and prefix-specific cross-ref keys (e.g. fig-cap, tbl-alt).
+--- The underscore rule is what `serialise_opts` uses to keep internal keys out of
+--- the cache key, so one convention covers both and a new internal key is safe by
+--- its name alone.
 --- @param key string
 --- @return boolean
 local function is_known_key(key)
+  if key:sub(1, 1) == '_' then
+    return true
+  end
   if KNOWN_KEYS[key] then
     return true
   end
@@ -274,8 +279,8 @@ end
 --- Cached brand module (nil = not yet attempted, false = unavailable)
 local brand_module = nil
 
---- Memoised `_typst_render_brand` literals, keyed by brand mode.
-local brand_literal_cache = {}
+--- Memoised `_typst_render_brand` let-bindings, keyed by brand mode.
+local brand_binding_cache = {}
 
 --- Load the Quarto brand module if available.
 --- @return table|nil The brand module, or nil if unavailable
@@ -330,54 +335,41 @@ local BRAND_COLOUR_ROLES = {
 --- already has it, and brand sizes are relative units with no pt equivalent.
 local BRAND_TYPOGRAPHY_ENTRIES = { 'base', 'headings' }
 
---- Normalise a CSS colour to a brand.yml hex string.
+--- Keep a brand colour when it is a CSS hex string, the form a brand.yml reader
+--- expects.
 --- The brand dictionary carries brand.yml *values*, not Typst expressions, so a
 --- consumer reads them the same way it reads the file itself. Such a consumer
---- takes hex only, and would read a CSS keyword as a palette entry name.
---- @param css string CSS colour string from the brand module
---- @return string|nil "#rgb", "#rgba", "#rrggbb", or "#rrggbbaa", else nil
+--- takes hex only, and would read any other notation as a palette entry name.
+--- @param css string Colour string from the brand module
+--- @return string|nil The value unchanged when it is hex, else nil
 local function brand_colour_to_hex(css)
-  if type(css) ~= 'string' then return nil end
   local digits = css:match('^#(%x+)$')
-  if digits then
-    local count = #digits
-    if count == 3 or count == 4 or count == 6 or count == 8 then return css end
-    return nil
-  end
-  local args = css:match('^rgba?%((.+)%)$')
-  if not args then return nil end
-  local components = {}
-  for part in args:gmatch('[^,%s/]+') do components[#components + 1] = part end
-  if #components < 3 then return nil end
-  local out = { '#' }
-  for index = 1, 3 do
-    local percent = components[index]:match('^(%d+%.?%d*)%%$')
-    local value = percent and (tonumber(percent) * 255 / 100) or tonumber(components[index])
-    if not value then return nil end
-    value = math.min(math.max(value, 0), 255)
-    out[#out + 1] = string.format('%02X', math.floor(value + 0.5))
-  end
-  return table.concat(out)
+  if not digits then return nil end
+  local count = #digits
+  -- Valid CSS hex colours are exactly 3, 4, 6, or 8 digits.
+  if count == 3 or count == 4 or count == 6 or count == 8 then return css end
+  return nil
 end
 
 --- Build the brand dictionary for one mode, in brand.yml shape.
 --- Quarto's brand module has already followed palette aliases and light/dark
 --- variants, so a downstream resolver has nothing left to do.
+--- Returns an empty table when the document has no brand, so a caller has one
+--- shape to handle rather than two.
 --- @param mode string "light" or "dark"
---- @return table|nil Table with `color` and `typography` keys, or nil when empty
+--- @return table Table with `color` and `typography` keys, empty without a brand
 local function build_brand_dict(mode)
+  local dict = {}
   local brand = get_brand_module()
-  if not brand or not brand.get_color_css then return nil end
+  if not brand or not brand.get_color_css then return dict end
 
+  -- A brand that carries one mode answers for that mode whichever side is
+  -- asked for. When it carries neither, every lookup below returns nil and the
+  -- dictionary comes out empty, which is the wanted result.
   local resolved_mode = mode
-  if brand.has_mode then
-    local ok, present = pcall(brand.has_mode, mode)
-    if ok and not present then
-      local other = mode == 'light' and 'dark' or 'light'
-      local ok_other, present_other = pcall(brand.has_mode, other)
-      if not (ok_other and present_other) then return nil end
-      resolved_mode = other
-    end
+  local ok_mode, present = pcall(brand.has_mode, mode)
+  if ok_mode and not present then
+    resolved_mode = mode == 'light' and 'dark' or 'light'
   end
 
   local colours = {}
@@ -390,43 +382,37 @@ local function build_brand_dict(mode)
       else
         log.log_warning(
           EXTENSION_NAME,
-          'Brand colour "' .. role .. '" is "' .. css .. '", which is not a hex value; '
-          .. 'omitting it from _typst_render_brand.'
+          'The brand dictionary carries hex colours only, so the "' .. role
+          .. '" role, written as "' .. css .. '", is left out of _typst_render_brand.'
         )
       end
     end
   end
 
   local typography = {}
-  if brand.get_typography then
-    for _, name in ipairs(BRAND_TYPOGRAPHY_ENTRIES) do
-      local ok, font = pcall(brand.get_typography, resolved_mode, name)
-      if ok and font then
-        local family = type(font) == 'table' and font.family or font
-        if type(family) == 'string' and family ~= '' then
-          typography[name] = { family = family }
-        end
-      end
+  for _, name in ipairs(BRAND_TYPOGRAPHY_ENTRIES) do
+    local ok, font = pcall(brand.get_typography, resolved_mode, name)
+    if ok and type(font) == 'table' and type(font.family) == 'string' and font.family ~= '' then
+      typography[name] = { family = font.family }
     end
   end
 
-  local dict = {}
   if next(colours) ~= nil then dict.color = colours end
   if next(typography) ~= nil then dict.typography = typography end
-  if next(dict) == nil then return nil end
   return dict
 end
 
---- Return the `_typst_render_brand` Typst literal for a mode, memoised per render.
+--- Return the `_typst_render_brand` let-binding for a mode, memoised per render.
+--- The whole line is cached rather than the dictionary alone: it is byte-identical
+--- for every block, and the caller runs once per block and inline expression.
 --- @param mode string "light" or "dark"
---- @return string Typst dictionary literal, `(:)` when the document has no brand
-local function brand_literal(mode)
-  local cached = brand_literal_cache[mode]
+--- @return string Typst let-binding, holding `(:)` without a brand
+local function brand_binding(mode)
+  local cached = brand_binding_cache[mode]
   if cached then return cached end
-  local dict = build_brand_dict(mode)
-  local literal = dict and to_typst_literal(dict) or '(:)'
-  brand_literal_cache[mode] = literal
-  return literal
+  local binding = '#let _typst_render_brand = ' .. to_typst_literal(build_brand_dict(mode))
+  brand_binding_cache[mode] = binding
+  return binding
 end
 
 --- Resolve a colour option to a config value preserving both modes when available.
@@ -869,23 +855,22 @@ local function typst_colour_to_hex(typst_expr)
   return typst_expr:match('^rgb%("(#[%x]+)"%)$')
 end
 
---- Prepend Typst let-bindings for the render background/foreground variables and
---- the document brand dictionary.
+--- Prepend the Typst let-bindings every block and inline expression receives:
+--- the render background and foreground, and the document brand dictionary.
 --- These make document colours and brand data available to library code under
---- predictable names. The brand dictionary is always bound, empty when the
---- document has no brand, so consuming code compiles either way.
+--- predictable names. All three are always bound, so consuming code compiles
+--- whether or not the document sets colours or carries a brand.
 --- @param parts table String parts list to append to
 --- @param opts table Options containing background, optional foreground, and
 ---   optionally `_brand_mode` when compiling one side of a light/dark pair
-local function inject_colour_vars(parts, opts)
+local function inject_render_bindings(parts, opts)
   parts[#parts + 1] = '#let _typst_render_background = ' .. opts.background
   if opts.foreground then
     parts[#parts + 1] = '#let _typst_render_foreground = ' .. opts.foreground
   else
     parts[#parts + 1] = '#let _typst_render_foreground = none'
   end
-  parts[#parts + 1] = '#let _typst_render_brand = '
-      .. brand_literal(opts._brand_mode or global_brand_mode)
+  parts[#parts + 1] = brand_binding(opts._brand_mode or global_brand_mode)
 end
 
 --- Build the `#set page(...)` directive from options (for image compilation).
@@ -916,7 +901,7 @@ end
 --- @return string Complete Typst source
 local function build_typst_source(code, opts, include_page)
   local parts = {}
-  inject_colour_vars(parts, opts)
+  inject_render_bindings(parts, opts)
   local define_preamble = build_define_preamble()
   if define_preamble then
     parts[#parts + 1] = define_preamble
@@ -936,27 +921,13 @@ local function build_typst_source(code, opts, include_page)
 end
 
 --- Build the inner Typst source for `output: asis` pass-through.
---- Unlike build_typst_source there is no `#set page(...)`: the code is emitted
---- into the document Typst is already laying out, so it inherits the page.
+--- There is no `#set page(...)`: the code is emitted into the document Typst is
+--- already laying out, so it inherits the page.
 --- @param code string User Typst code
 --- @param opts table Merged options (colours must be plain strings)
 --- @return string Typst source to place inside a `#[ ... ]` scope
 local function build_asis_inner(code, opts)
-  local parts = {}
-  inject_colour_vars(parts, opts)
-  local define_preamble = build_define_preamble()
-  if define_preamble then
-    parts[#parts + 1] = define_preamble
-  end
-  if opts.foreground then
-    parts[#parts + 1] = '#set text(fill: ' .. opts.foreground .. ')'
-  end
-  local preamble = resolve_preamble(opts.preamble)
-  if preamble then
-    parts[#parts + 1] = preamble
-  end
-  parts[#parts + 1] = code
-  return table.concat(parts, '\n')
+  return build_typst_source(code, opts, false)
 end
 
 --- Build a human-readable cache file stem from label or block number and a
@@ -1370,7 +1341,7 @@ local function compile_typst(source, opts, img_format)
   -- Expose document colours to library theme functions via sys.inputs.
   -- Only hex colours (rgb("#RRGGBB")) can be round-tripped through a CLI flag;
   -- other expressions (oklch, named colours) are available via the #let bindings
-  -- injected by inject_colour_vars and do not need a separate --input flag.
+  -- injected by inject_render_bindings and do not need a separate --input flag.
   local fg_hex = typst_colour_to_hex(opts.foreground)
   local bg_hex = typst_colour_to_hex(opts.background)
   if fg_hex then
@@ -1746,8 +1717,8 @@ local function get_configuration(meta)
   register_custom_crossref_types(meta)
   read_file_cache = {}
   -- Quarto reuses the Lua state across documents in a project render, so a brand
-  -- literal built for one document must not leak into the next.
-  brand_literal_cache = {}
+  -- binding built for one document must not leak into the next.
+  brand_binding_cache = {}
   -- Quarto may reuse the Lua state across documents; re-inject the Typst head
   -- CSS for each document that produces native HTML output.
   typst_cli.reset_head_injection()

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -282,6 +282,10 @@ local brand_module = nil
 --- Memoised `_typst_render_brand` let-bindings, keyed by brand mode.
 local brand_binding_cache = {}
 
+--- Colour roles already reported as non-hex, so the warning is emitted once per
+--- document rather than once per brand mode.
+local brand_warned_roles = {}
+
 --- Load the Quarto brand module if available.
 --- @return table|nil The brand module, or nil if unavailable
 local function get_brand_module()
@@ -358,28 +362,50 @@ end
 --- shape to handle rather than two.
 --- @param mode string "light" or "dark"
 --- @return table Table with `color` and `typography` keys, empty without a brand
+--- Read one brand entry, falling back to the opposite mode when the wanted mode
+--- does not define it.
+--- The fallback is per entry, not per brand: Quarto marks a brand as carrying a
+--- dark mode as soon as any one role declares a dark value, so a role written
+--- for light only would otherwise vanish in dark mode. `background: auto` falls
+--- back the same way, and the two must agree.
+--- @param accessor function Brand module accessor taking (mode, name)
+--- @param mode string "light" or "dark"
+--- @param name string Colour role or typography entry name
+--- @param kind string Word for the log message, "colour" or "typography entry"
+--- @return any|nil The entry, or nil when neither mode defines it
+local function brand_lookup(accessor, mode, name, kind)
+  local other = mode == 'light' and 'dark' or 'light'
+  for _, side in ipairs({ mode, other }) do
+    local ok, value = pcall(accessor, side, name)
+    if not ok then
+      log.log_debug(
+        EXTENSION_NAME,
+        'Brand ' .. kind .. ' "' .. name .. '" could not be read for ' .. side
+        .. ' mode: ' .. tostring(value)
+      )
+    elseif value ~= nil and value ~= '' then
+      return value
+    end
+  end
+  return nil
+end
+
 local function build_brand_dict(mode)
   local dict = {}
   local brand = get_brand_module()
   if not brand or not brand.get_color_css then return dict end
 
-  -- A brand that carries one mode answers for that mode whichever side is
-  -- asked for. When it carries neither, every lookup below returns nil and the
-  -- dictionary comes out empty, which is the wanted result.
-  local resolved_mode = mode
-  local ok_mode, present = pcall(brand.has_mode, mode)
-  if ok_mode and not present then
-    resolved_mode = mode == 'light' and 'dark' or 'light'
-  end
-
   local colours = {}
   for _, role in ipairs(BRAND_COLOUR_ROLES) do
-    local ok, css = pcall(brand.get_color_css, resolved_mode, role)
-    if ok and type(css) == 'string' and css ~= '' then
+    local css = brand_lookup(brand.get_color_css, mode, role, 'colour')
+    if type(css) == 'string' then
       local hex = brand_colour_to_hex(css)
       if hex then
         colours[role] = hex
-      else
+      elseif not brand_warned_roles[role] then
+        -- Once per document: the dictionary is built once per mode, and the
+        -- brand file is the same on both sides.
+        brand_warned_roles[role] = true
         log.log_warning(
           EXTENSION_NAME,
           'The brand dictionary carries hex colours only, so the "' .. role
@@ -391,8 +417,8 @@ local function build_brand_dict(mode)
 
   local typography = {}
   for _, name in ipairs(BRAND_TYPOGRAPHY_ENTRIES) do
-    local ok, font = pcall(brand.get_typography, resolved_mode, name)
-    if ok and type(font) == 'table' and type(font.family) == 'string' and font.family ~= '' then
+    local font = brand_lookup(brand.get_typography, mode, name, 'typography entry')
+    if type(font) == 'table' and type(font.family) == 'string' and font.family ~= '' then
       typography[name] = { family = font.family }
     end
   end
@@ -1719,6 +1745,7 @@ local function get_configuration(meta)
   -- Quarto reuses the Lua state across documents in a project render, so a brand
   -- binding built for one document must not leak into the next.
   brand_binding_cache = {}
+  brand_warned_roles = {}
   -- Quarto may reuse the Lua state across documents; re-inject the Typst head
   -- CSS for each document that produces native HTML output.
   typst_cli.reset_head_injection()

--- a/_extensions/typst-render/typst-render.lua
+++ b/_extensions/typst-render/typst-render.lua
@@ -282,9 +282,8 @@ local brand_module = nil
 --- Memoised `_typst_render_brand` let-bindings, keyed by brand mode.
 local brand_binding_cache = {}
 
---- Colour roles already reported as non-hex, so the warning is emitted once per
---- document rather than once per brand mode.
-local brand_warned_roles = {}
+--- Whether the non-hex colour omission has been reported for this document.
+local brand_omission_warned = false
 
 --- Load the Quarto brand module if available.
 --- @return table|nil The brand module, or nil if unavailable
@@ -355,26 +354,32 @@ local function brand_colour_to_hex(css)
   return nil
 end
 
---- Build the brand dictionary for one mode, in brand.yml shape.
---- Quarto's brand module has already followed palette aliases and light/dark
---- variants, so a downstream resolver has nothing left to do.
---- Returns an empty table when the document has no brand, so a caller has one
---- shape to handle rather than two.
---- @param mode string "light" or "dark"
---- @return table Table with `color` and `typography` keys, empty without a brand
---- Read one brand entry, falling back to the opposite mode when the wanted mode
---- does not define it.
---- The fallback is per entry, not per brand: Quarto marks a brand as carrying a
---- dark mode as soon as any one role declares a dark value, so a role written
---- for light only would otherwise vanish in dark mode. `background: auto` falls
---- back the same way, and the two must agree.
+--- Keep a brand typography entry when it names a font family.
+--- @param font any Value from the brand module
+--- @return string|nil The family name, or nil when the entry names none
+local function brand_font_family(font)
+  if type(font) ~= 'table' then return nil end
+  if type(font.family) ~= 'string' or font.family == '' then return nil end
+  return font.family
+end
+
+--- Read one brand entry, scanning the wanted mode first and then the other.
+--- The scan is per entry, not per brand: Quarto marks a brand as carrying a dark
+--- mode as soon as any one role declares a dark value, so a role written for
+--- light only would otherwise vanish in dark mode. `background: auto` falls back
+--- the same way, and the two must agree. A mode that holds the entry in a form
+--- the dictionary cannot carry does not stop the scan either, so one unusable
+--- side never hides a usable one.
 --- @param accessor function Brand module accessor taking (mode, name)
 --- @param mode string "light" or "dark"
 --- @param name string Colour role or typography entry name
 --- @param kind string Word for the log message, "colour" or "typography entry"
---- @return any|nil The entry, or nil when neither mode defines it
-local function brand_lookup(accessor, mode, name, kind)
+--- @param keep function Maps a raw value to the value to carry, or nil to reject
+--- @return any|nil The kept value, or nil when neither mode offers one
+--- @return any|nil The first rejected value, for reporting
+local function brand_lookup(accessor, mode, name, kind, keep)
   local other = mode == 'light' and 'dark' or 'light'
+  local rejected = nil
   for _, side in ipairs({ mode, other }) do
     local ok, value = pcall(accessor, side, name)
     if not ok then
@@ -384,47 +389,57 @@ local function brand_lookup(accessor, mode, name, kind)
         .. ' mode: ' .. tostring(value)
       )
     elseif value ~= nil and value ~= '' then
-      return value
+      local kept = keep(value)
+      if kept ~= nil then return kept end
+      rejected = rejected or value
     end
   end
-  return nil
+  return nil, rejected
 end
 
+--- Build the brand dictionary for one mode, in brand.yml shape.
+--- Quarto's brand module has already followed palette aliases and light/dark
+--- variants, so a downstream resolver has nothing left to do.
+--- `color` and `typography` are always present, empty when the brand says
+--- nothing under them, so consuming code has one shape to read.
+--- @param mode string "light" or "dark"
+--- @return table Table with `color` and `typography` keys
 local function build_brand_dict(mode)
-  local dict = {}
+  local colours = {}
+  local typography = {}
+  local dict = { color = colours, typography = typography }
   local brand = get_brand_module()
   if not brand or not brand.get_color_css then return dict end
 
-  local colours = {}
+  local omitted = {}
   for _, role in ipairs(BRAND_COLOUR_ROLES) do
-    local css = brand_lookup(brand.get_color_css, mode, role, 'colour')
-    if type(css) == 'string' then
-      local hex = brand_colour_to_hex(css)
-      if hex then
-        colours[role] = hex
-      elseif not brand_warned_roles[role] then
-        -- Once per document: the dictionary is built once per mode, and the
-        -- brand file is the same on both sides.
-        brand_warned_roles[role] = true
-        log.log_warning(
-          EXTENSION_NAME,
-          'The brand dictionary carries hex colours only, so the "' .. role
-          .. '" role, written as "' .. css .. '", is left out of _typst_render_brand.'
-        )
-      end
+    local hex, rejected = brand_lookup(brand.get_color_css, mode, role, 'colour', brand_colour_to_hex)
+    if hex then
+      colours[role] = hex
+    elseif rejected then
+      omitted[#omitted + 1] = role
     end
   end
 
-  local typography = {}
+  -- One line per document rather than one per role per mode: the brand file is
+  -- the same on both sides, and a brand written in another notation would
+  -- otherwise report every role it defines, twice.
+  if #omitted > 0 and not brand_omission_warned then
+    brand_omission_warned = true
+    log.log_warning(
+      EXTENSION_NAME,
+      '_typst_render_brand carries hex colours only, so these roles are left out of it: '
+      .. table.concat(omitted, ', ') .. '. Colour options such as `background: auto` are unaffected.'
+    )
+  end
+
   for _, name in ipairs(BRAND_TYPOGRAPHY_ENTRIES) do
-    local font = brand_lookup(brand.get_typography, mode, name, 'typography entry')
-    if type(font) == 'table' and type(font.family) == 'string' and font.family ~= '' then
-      typography[name] = { family = font.family }
+    local family = brand_lookup(brand.get_typography, mode, name, 'typography entry', brand_font_family)
+    if family then
+      typography[name] = { family = family }
     end
   end
 
-  if next(colours) ~= nil then dict.color = colours end
-  if next(typography) ~= nil then dict.typography = typography end
   return dict
 end
 
@@ -1745,7 +1760,7 @@ local function get_configuration(meta)
   -- Quarto reuses the Lua state across documents in a project render, so a brand
   -- binding built for one document must not leak into the next.
   brand_binding_cache = {}
-  brand_warned_roles = {}
+  brand_omission_warned = false
   -- Quarto may reuse the Lua state across documents; re-inject the Typst head
   -- CSS for each document that produces native HTML output.
   typst_cli.reset_head_injection()

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -76,6 +76,47 @@ Inline Typst is not available in PowerPoint, since Pandoc cannot put an image in
 Blocks work normally.
 :::
 
+## Brand colours
+
+The document brand is bound as `_typst_render_brand`, a dictionary in `_brand.yml` shape, so a figure can draw itself in the colours of the site around it.
+This page uses the pastel brand shared by these documentation sites.
+
+`background: auto` compiles the block once per colour scheme, and the dictionary matches the side being compiled, so the swatches below change with the theme of the page.
+
+```{typst}
+//| echo: true
+//| background: auto
+#let roles = ("primary", "secondary", "tertiary", "success", "info", "warning", "danger")
+#let colours = _typst_render_brand.at("color", default: (:))
+#stack(
+  dir: ltr,
+  spacing: 4pt,
+  ..roles
+    .filter(role => role in colours)
+    .map(role => rect(width: 1.4cm, height: 1.4cm, radius: 3pt, fill: rgb(colours.at(role)))),
+)
+```
+
+A plotting package that reads `_brand.yml` takes the dictionary directly.
+[Gribouille](https://github.com/mcanouil/gribouille) is one, from version 0.7.0:
+
+````markdown
+```{typst}
+#import "@preview/gribouille:0.7.0": *
+
+#plot(
+  data: (x: (1, 2, 3, 4), y: (2, 4, 3, 5), g: ("a", "b", "a", "b")),
+  mapping: aes(x: "x", y: "y", colour: "g"),
+  layers: (geom-point(size: 5pt),),
+  theme: theme-brand(_typst_render_brand),
+  width: 8cm,
+  height: 5cm,
+)
+```
+````
+
+The reference page lists [every binding and every brand role](reference.qmd#brand-data) that reaches a block.
+
 ## Showing the source
 
 `echo` puts the Typst beside its output, and `code-fold` tucks it away:

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -87,7 +87,7 @@ This page uses the pastel brand shared by these documentation sites.
 //| echo: true
 //| background: auto
 #let roles = ("primary", "secondary", "tertiary", "success", "info", "warning", "danger")
-#let colours = _typst_render_brand.at("color", default: (:))
+#let colours = _typst_render_brand.color
 #stack(
   dir: ltr,
   spacing: 4pt,

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -121,7 +121,7 @@ Three bindings are placed ahead of every block and every inline expression, so l
 
 : Bindings available inside a `{typst}` block. {.striped .hover tbl-colwidths="[34,66]"}
 
-`_typst_render_brand` holds `color` and `typography` keys:
+`_typst_render_brand` always holds a `color` key and a `typography` key, each empty when the brand says nothing under it:
 
 ```typ
 #let _typst_render_brand = (
@@ -143,11 +143,14 @@ A role or a family written for one mode only is carried into both, so a brand th
 
 `background: auto` reads the same brand role as `_typst_render_brand.color.background`, in a different form: a Typst colour ready for `fill:`, rather than the `_brand.yml` string.
 
-A block with no brand still compiles, because an empty dictionary is bound:
+A block with no brand still compiles, because the two keys are bound empty:
 
 ```typ
-#let _typst_render_brand = (:)
+#let _typst_render_brand = ("color": (:), "typography": (:))
 ```
+
+A role is a different matter: read one that the brand does not define and Typst stops.
+Use `.at(name, default: ...)` for a role the brand may leave out.
 
 ## Interactions
 

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -109,6 +109,45 @@ Every other writer compiles an image, as it does for a block.
 
 When `background` or `foreground` carries both a `light` and a `dark` value, an expression in HTML output is compiled twice and both images are emitted, marked with Quarto's `light-content` and `dark-content` so the page shows the one matching its mode.
 
+## Brand data
+
+Three bindings are placed ahead of every block and every inline expression, so library code can read them under known names.
+
+| Binding | Value |
+| --- | --- |
+| `_typst_render_background` | The resolved `background`, as a Typst colour. `none` when unset. |
+| `_typst_render_foreground` | The resolved `foreground`, as a Typst colour. `none` when unset. |
+| `_typst_render_brand` | The document brand, as a dictionary in `_brand.yml` shape. Empty when the document has no brand. |
+
+: Bindings available inside a `{typst}` block. {.striped .hover tbl-colwidths="[34,66]"}
+
+`_typst_render_brand` holds `color` and `typography` keys:
+
+```typ
+#let _typst_render_brand = (
+  "color": ("background": "#FFFAF0", "foreground": "#1A1A1A", "primary": "#E94C3D"),
+  "typography": ("base": ("family": "Inter"), "headings": ("family": "Inter")),
+)
+```
+
+Under `color` are the nine semantic roles that a chart can act on: `foreground`, `background`, `primary`, `secondary`, `tertiary`, `success`, `info`, `warning`, and `danger`.
+Quarto resolves palette aliases first, so each value is a hex string.
+A role written as a CSS keyword, such as `red`, is left out with a warning, because a hex value is what a `_brand.yml` reader expects.
+Under `typography` are the `base` and `headings` families.
+Sizes and weights are left out, because Typst can use a font family only when the compiler already has it.
+
+The dictionary follows the document `brand-mode`, so a dark document gets the dark values.
+It is not itself a reason to compile twice: `background: auto` or `foreground: auto` is what produces a light and dark pair, and the dictionary then matches the side being compiled.
+
+`background: auto` and `_typst_render_brand.color.background` describe the same colour.
+They differ in form only: the first is a Typst colour, ready for `fill:`, and the second is the `_brand.yml` string.
+
+A block with no brand still compiles, because an empty dictionary is bound:
+
+```typ
+#let _typst_render_brand = (:)
+```
+
 ## Interactions
 
 ::: {.callout-caution}

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -117,7 +117,7 @@ Three bindings are placed ahead of every block and every inline expression, so l
 | --- | --- |
 | `_typst_render_background` | The resolved `background`, as a Typst colour. `none` when unset. |
 | `_typst_render_foreground` | The resolved `foreground`, as a Typst colour. `none` when unset. |
-| `_typst_render_brand` | The document brand, as a dictionary in `_brand.yml` shape. Empty when the document has no brand. |
+| `_typst_render_brand` | The document brand, as a dictionary in `_brand.yml` shape. |
 
 : Bindings available inside a `{typst}` block. {.striped .hover tbl-colwidths="[34,66]"}
 
@@ -131,16 +131,16 @@ Three bindings are placed ahead of every block and every inline expression, so l
 ```
 
 Under `color` are the nine semantic roles that a chart can act on: `foreground`, `background`, `primary`, `secondary`, `tertiary`, `success`, `info`, `warning`, and `danger`.
-Quarto resolves palette aliases first, so each value is a hex string.
-A role written as a CSS keyword, such as `red`, is left out with a warning, because a hex value is what a `_brand.yml` reader expects.
+Quarto resolves palette aliases first, and every value is carried as written in the brand file.
+Only hex values reach the dictionary, because hex is what a `_brand.yml` reader expects.
+A role written in any other notation, such as `red` or `oklch(...)`, is left out with a warning naming it.
 Under `typography` are the `base` and `headings` families.
 Sizes and weights are left out, because Typst can use a font family only when the compiler already has it.
 
 The dictionary follows the document `brand-mode`, so a dark document gets the dark values.
 It is not itself a reason to compile twice: `background: auto` or `foreground: auto` is what produces a light and dark pair, and the dictionary then matches the side being compiled.
 
-`background: auto` and `_typst_render_brand.color.background` describe the same colour.
-They differ in form only: the first is a Typst colour, ready for `fill:`, and the second is the `_brand.yml` string.
+`background: auto` reads the same brand role as `_typst_render_brand.color.background`, in a different form: a Typst colour ready for `fill:`, rather than the `_brand.yml` string.
 
 A block with no brand still compiles, because an empty dictionary is bound:
 

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -139,6 +139,7 @@ Sizes and weights are left out, because Typst can use a font family only when th
 
 The dictionary follows the document `brand-mode`, so a dark document gets the dark values.
 It is not itself a reason to compile twice: `background: auto` or `foreground: auto` is what produces a light and dark pair, and the dictionary then matches the side being compiled.
+A role or a family written for one mode only is carried into both, so a brand that gives `secondary` a light value and no dark value keeps that value in dark mode.
 
 `background: auto` reads the same brand role as `_typst_render_brand.color.background`, in a different form: a Typst colour ready for `fill:`, rather than the `_brand.yml` string.
 

--- a/example.qmd
+++ b/example.qmd
@@ -478,7 +478,7 @@ This document has no `_brand.yml`, so the dictionary is empty and the block belo
 ```{typst}
 //| echo: fenced
 #let roles = ("primary", "secondary", "tertiary", "success", "info", "warning", "danger")
-#let colours = _typst_render_brand.at("color", default: (:))
+#let colours = _typst_render_brand.color
 #let swatches = roles.filter(role => role in colours)
 #if swatches.len() == 0 [
   #text(size: 14pt)[No brand]

--- a/example.qmd
+++ b/example.qmd
@@ -466,6 +466,33 @@ Global inputs are set in YAML; per-block inputs override them using comma-separa
 
 :::
 
+## Brand Data
+
+::: {.content-hidden when-format="typst"}
+
+The document brand is bound as `_typst_render_brand`, a dictionary in `_brand.yml` shape.
+Under `color` are `foreground`, `background`, `primary`, `secondary`, `tertiary`, `success`, `info`, `warning`, and `danger`, each a hex string.
+Under `typography` are the `base` and `headings` families.
+This document has no `_brand.yml`, so the dictionary is empty and the block below falls back.
+
+```{typst}
+//| echo: fenced
+#let roles = ("primary", "secondary", "tertiary", "success", "info", "warning", "danger")
+#let colours = _typst_render_brand.at("color", default: (:))
+#let swatches = roles.filter(role => role in colours)
+#if swatches.len() == 0 [
+  #text(size: 14pt)[No brand]
+] else [
+  #stack(
+    dir: ltr,
+    spacing: 4pt,
+    ..swatches.map(role => rect(width: 1cm, height: 1cm, fill: rgb(colours.at(role)))),
+  )
+]
+```
+
+:::
+
 ## Passing Data from R/Python
 
 Use `typst_define()` to push named values from a knitr or jupyter session into every `{typst}` cell.


### PR DESCRIPTION
A Typst package that reads `_brand.yml` cannot open the file itself: a relative `yaml()` path resolves against the calling file, and block source reaches the compiler over stdin. Gribouille 0.7.0 makes this concrete with `theme-brand(brand)`, which takes a dictionary rather than a path.

Every block and inline expression now receives `_typst_render_brand`, a dictionary in `_brand.yml` shape:

```typ
#let _typst_render_brand = (
  "color": ("background": "#FFFAF0", "foreground": "#1A1A1A", "primary": "#E94C3D"),
  "typography": ("base": ("family": "Inter"), "headings": ("family": "Inter")),
)
```

Under `color` are the nine semantic roles a chart can act on, and under `typography` the `base` and `headings` families. Both keys are always bound, empty when the brand says nothing under them. Values come from Quarto’s brand module, which the filter already used for `background: auto` and `foreground: auto`, so this widens the existing bridge rather than adding a second source of brand data. `QUARTO_EXECUTE_INFO` is not involved: it carries brand only incidentally, and goes stale on a freeze-cache hit.

- The dictionary follows `brand-mode` and the side being compiled, so `background: auto` produces a light and dark pair whose dictionaries match their images.
- A role or family written for one mode is carried into both, matching how the colour options already fall back.
- Only hex values are carried, because that is what a `_brand.yml` reader expects. Roles in another notation are named in one warning line per document, and the colour options still handle them.
- Filter-internal option keys are now claimed by their leading underscore rather than by a hand-maintained list, which is what kept `_brand_mode` out of the rendered `<img>` tags.
- `build_asis_inner` was identical to `build_typst_source(code, opts, false)` and is now a delegation.

The reference page gains a "Brand data" section covering all three injected bindings, and both example pages draw brand swatches. The Gribouille snippet is shown unevaluated until 0.7.0 reaches Typst Universe.

Also included: a separate style commit quoting the `@module` names in the shared module headers.

Every cached image is compiled again on the first render after this change, since the binding is part of the source the cache key is built from.