### PR TITLE
docs: document engines and typst_define

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Documentation
+
+- docs: Record how each Quarto engine treats a `{typst}` block, and give the passthrough engine that `knitr` needs to stop claiming the cell and producing no figure. (#97)
+- docs: Document the `typst_define()` helpers on the reference page: the loader for each language, the value types carried, and the key order they reach Typst in. (#97)
+
 ## 0.22.0 (2026-09-07)
 
 ### New Features

--- a/_extensions/typst-render/_resources/typst_define.R
+++ b/_extensions/typst-render/_resources/typst_define.R
@@ -27,7 +27,8 @@ if (requireNamespace("knitr", quietly = TRUE)) {
 #' Emits a Pandoc YAML metadata block carrying a JSON payload that the
 #' typst-render Lua filter ingests and converts into a
 #' `#let typst_define = (...)` binding available in every `{typst}` code
-#' block from that point onward.
+#' block of the document. The filter ingests the metadata before it processes
+#' any block, so a block above this call sees the values as well.
 #'
 #' @param ... Named or positional values.
 #'   Unnamed positional values use the deparsed expression as the key.

--- a/_extensions/typst-render/_resources/typst_define.py
+++ b/_extensions/typst-render/_resources/typst_define.py
@@ -3,7 +3,8 @@
 Emits a Pandoc YAML metadata block carrying a hex-encoded JSON payload that
 the typst-render Lua filter ingests and converts into a
 `#let typst_define = (...)` binding available in every `{typst}` code block
-from that point onward.
+of the document. The filter ingests the metadata before it processes any
+block, so a block above this call sees the values as well.
 """
 
 import importlib
@@ -33,14 +34,13 @@ def _convert(v):
 
 def typst_define(**kwargs):
     import json
-    from IPython.display import display, Markdown
+
+    from IPython.display import Markdown, display
 
     for k, v in kwargs.items():
         _typst_define_state[k] = _convert(v)
     payload = {
-        "contents": [
-            {"name": k, "value": v} for k, v in _typst_define_state.items()
-        ]
+        "contents": [{"name": k, "value": v} for k, v in _typst_define_state.items()]
     }
     encoded = json.dumps(payload).encode("utf-8").hex()
     display(Markdown(f"\n---\ntypst-define: {encoded}\n---\n"))

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -24,9 +24,8 @@ The document engine sees it before the filter does, and not every engine leaves 
 | Engine | What happens | What you do |
 | --- | --- | --- |
 | `markdown` | The block reaches the filter untouched. | Nothing. Best for a document with no executable code, as `example.qmd` and these pages are. |
-| `jupyter` | The block passes through the notebook conversion untouched. | Nothing. |
-| `julia` | The block passes through untouched. | Nothing. |
-| `knitr` | knitr claims the cell and knows no `typst` engine, so no figure is produced. | Register a passthrough engine, as below. |
+| `jupyter`, `julia` | The block passes through untouched. | Nothing. |
+| `knitr` | knitr claims the cell and knows no `typst` engine, so it produces no figure. | Register a passthrough engine, as below. |
 | none | Engine detection selects Jupyter, which then fails for want of a kernel. | Set `engine: markdown`, or name the engine you want. |
 
 : How each engine treats a `{typst}` block. {.striped .hover tbl-colwidths="[14,45,41]"}
@@ -57,7 +56,7 @@ The R helper in [Passing data from R or Python](#passing-data-from-r-or-python) 
 
 ## Passing data from R or Python
 
-`typst_define()` pushes named values from a knitr or jupyter session into every `{typst}` block that follows the call.
+`typst_define()` pushes named values from a knitr or jupyter session into the `{typst}` blocks of the document.
 Each value is read back as `#typst_define.<name>`.
 
 Two helpers ship with the extension, under `_extensions/mcanouil/typst-render/_resources/`.
@@ -84,31 +83,27 @@ from typst_define import typst_define
 Call it wherever the values are ready:
 
 ```r
-typst_define(mtcars = head(mtcars)[, c("mpg", "cyl", "hp")], n = 42L)
+typst_define(n = 42L, d = data.frame(mpg = c(21, 22.8), cyl = c(6L, 4L)))
 ```
 
 The call emits a hidden metadata block, so it adds nothing to the page.
 The chunk source is still echoed under the usual `echo` and `include` options.
 
-The values are then in scope in every block below:
+Read the values by name:
 
 ```typ
-n = #typst_define.n
-
-#let df = typst_define.mtcars
-#let cols = df.keys()
-#table(
-  columns: cols.len(),
-  table.header(..cols.map(c => [*#c*])),
-  ..for i in range(df.at(cols.at(0)).len()) {
-    cols.map(c => [#df.at(c).at(i)])
-  }
-)
+n is #typst_define.n, and the first mpg is #typst_define.d.mpg.at(0).
 ```
 
+Every `{typst}` block of the document reads the same values, wherever it sits.
+The engine runs the whole document before the filter does, so a block above the call sees them as well.
+
 Scalars, strings, booleans, arrays, and nested objects are carried as written.
-An R data frame is carried column-wise, as a dictionary of arrays, and a pandas or polars DataFrame is carried the same way.
+An R, pandas, or polars data frame is carried column-wise, as a dictionary of arrays.
 A numpy array becomes a Typst array.
+
+Keys arrive sorted by name rather than in the order they were written, so read a column by name and never by position.
+An R data frame with row names carries them under an added `_row` key.
 
 Each call adds to the values already defined, and a repeated name takes the newer value.
 The payload travels as hex-encoded JSON, because Pandoc's smart quotes and dashes would otherwise corrupt it.
@@ -254,5 +249,5 @@ Do not run both on the same document.
 ## Limitations
 
 - Inline Typst is not available in PowerPoint: Pandoc cannot put an image inside a run of text there. Blocks work normally.
-- A document with no engine declared falls to Jupyter, which needs a kernel. The `knitr` engine needs a passthrough engine registered. See [Engines](#engines).
+- The document engine decides whether a `{typst}` block reaches the filter at all. See [Engines](#engines).
 - `format: html` needs Typst 0.15 or later, and falls back to SVG below that.

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -47,7 +47,7 @@ Register a passthrough engine in a setup chunk, so that knitr hands the block ba
 ````r
 #| include: false
 knitr::knit_engines$set(typst = function(options) {
-  knitr::asis_output(paste0("\n```{typst}\n", paste(options$code, collapse = "\n"), "\n```\n"))
+  knitr::asis_output(paste0("\n```{typst}\n", paste(options[["code"]], collapse = "\n"), "\n```\n"))
 })
 ````
 
@@ -102,7 +102,8 @@ Scalars, strings, booleans, arrays, and nested objects are carried as written.
 An R, pandas, or polars data frame is carried column-wise, as a dictionary of arrays.
 A numpy array becomes a Typst array.
 
-Keys arrive sorted by name rather than in the order they were written, so read a column by name and never by position.
+Names keep the order of the calls that defined them.
+Inside a carried object or data frame, however, the keys arrive sorted by name, so read a column by name and never by position.
 An R data frame with row names carries them under an added `_row` key.
 
 Each call adds to the values already defined, and a repeated name takes the newer value.

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -16,10 +16,102 @@ Reference it by name, with no `at:` stage.
 It registers itself at the several stages it needs, and pinning it to one breaks cross-referencing and the `math: typst` takeover.
 :::
 
-::: {.callout-caution}
-A ```` ```{typst} ```` block looks like an executable cell to Quarto's engine detection, which then selects Jupyter and fails for want of a kernel.
-Set `engine: markdown` on any document that uses one; the repository's own `example.qmd` does.
-:::
+## Engines
+
+A ```` ```{typst} ```` block looks like an executable cell to Quarto.
+The document engine sees it before the filter does, and not every engine leaves it alone.
+
+| Engine | What happens | What you do |
+| --- | --- | --- |
+| `markdown` | The block reaches the filter untouched. | Nothing. Best for a document with no executable code, as `example.qmd` and these pages are. |
+| `jupyter` | The block passes through the notebook conversion untouched. | Nothing. |
+| `julia` | The block passes through untouched. | Nothing. |
+| `knitr` | knitr claims the cell and knows no `typst` engine, so no figure is produced. | Register a passthrough engine, as below. |
+| none | Engine detection selects Jupyter, which then fails for want of a kernel. | Set `engine: markdown`, or name the engine you want. |
+
+: How each engine treats a `{typst}` block. {.striped .hover tbl-colwidths="[14,45,41]"}
+
+An inline `` `{typst}` `` expression is ordinary inline code, so every engine leaves it alone.
+
+### knitr
+
+knitr writes this warning:
+
+```text
+Unknown language engine 'typst' (must be registered via knit_engines$set()).
+```
+
+The block then reaches the page as highlighted Typst source, with no figure beside it.
+
+Register a passthrough engine in a setup chunk, so that knitr hands the block back unchanged:
+
+````r
+#| include: false
+knitr::knit_engines$set(typst = function(options) {
+  knitr::asis_output(paste0("\n```{typst}\n", paste(options$code, collapse = "\n"), "\n```\n"))
+})
+````
+
+Per-block options, cross-reference labels, and captions all work after that.
+The R helper in [Passing data from R or Python](#passing-data-from-r-or-python) performs the same registration, so a document that calls `typst_define()` needs nothing more.
+
+## Passing data from R or Python
+
+`typst_define()` pushes named values from a knitr or jupyter session into every `{typst}` block that follows the call.
+Each value is read back as `#typst_define.<name>`.
+
+Two helpers ship with the extension, under `_extensions/mcanouil/typst-render/_resources/`.
+There is no Julia helper, so this feature covers knitr and jupyter only.
+
+The R helper needs `rlang` and `jsonlite`.
+Load it in a setup chunk:
+
+```r
+#| include: false
+source("_extensions/mcanouil/typst-render/_resources/typst_define.R")
+```
+
+The Python helper needs `IPython`.
+Load it the same way:
+
+```python
+#| include: false
+import sys
+sys.path.insert(0, "_extensions/mcanouil/typst-render/_resources")
+from typst_define import typst_define
+```
+
+Call it wherever the values are ready:
+
+```r
+typst_define(mtcars = head(mtcars)[, c("mpg", "cyl", "hp")], n = 42L)
+```
+
+The call emits a hidden metadata block, so it adds nothing to the page.
+The chunk source is still echoed under the usual `echo` and `include` options.
+
+The values are then in scope in every block below:
+
+```typ
+n = #typst_define.n
+
+#let df = typst_define.mtcars
+#let cols = df.keys()
+#table(
+  columns: cols.len(),
+  table.header(..cols.map(c => [*#c*])),
+  ..for i in range(df.at(cols.at(0)).len()) {
+    cols.map(c => [#df.at(c).at(i)])
+  }
+)
+```
+
+Scalars, strings, booleans, arrays, and nested objects are carried as written.
+An R data frame is carried column-wise, as a dictionary of arrays, and a pandas or polars DataFrame is carried the same way.
+A numpy array becomes a Typst array.
+
+Each call adds to the values already defined, and a repeated name takes the newer value.
+The payload travels as hex-encoded JSON, because Pandoc's smart quotes and dashes would otherwise corrupt it.
 
 ## Global options
 
@@ -162,5 +254,5 @@ Do not run both on the same document.
 ## Limitations
 
 - Inline Typst is not available in PowerPoint: Pandoc cannot put an image inside a run of text there. Blocks work normally.
-- `engine: markdown` is required on documents containing `{typst}` blocks.
+- A document with no engine declared falls to Jupyter, which needs a kernel. The `knitr` engine needs a passthrough engine registered. See [Engines](#engines).
 - `format: html` needs Typst 0.15 or later, and falls back to SVG below that.


### PR DESCRIPTION
The reference page told every reader to set `engine: markdown` and said nothing else about engines. That is only one of four working answers, and it left the case reported in #75 undocumented: under `knitr` the cell is claimed before the filter sees it, knitr warns that it knows no `typst` engine, and the block reaches the page as highlighted source with no figure.

A new "Engines" section gives the behaviour of each engine and the passthrough registration that `knitr` needs. `typst_define()` also gets a section, since the one feature that requires a real engine had no reference on the site at all.

- The `jupyter` and `julia` engines pass `{typst}` blocks through untouched, so they need no setup. Only `knitr` does.
- The `typst_define()` section covers the loader for each language, the dependencies, the value types carried, the key order they reach Typst in, and the accumulate semantics.
- The `output: asis` requirement recorded when the helpers landed no longer holds, in either engine, so it is left out.
- The helper docstrings said the binding reached only the blocks below the call. The filter ingests the metadata before it processes any block, so a block above the call sees the values too.

Verified by rendering: `knitr` before and after registration, `jupyter`, `julia`, no engine declared, and `typst_define()` end to end in both engines.