### PR TITLE
docs: show the full Quarto cell in the setup examples

### DIFF
--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -44,7 +44,7 @@ The block then reaches the page as highlighted Typst source, with no figure besi
 
 Register a passthrough engine in a setup chunk, so that knitr hands the block back unchanged:
 
-````quarto
+````markdown
 ```{{r}}
 #| include: false
 knitr::knit_engines$set(typst = function(options) {
@@ -67,7 +67,7 @@ There is no Julia helper, so this feature covers knitr and jupyter only.
 The R helper needs `rlang` and `jsonlite`.
 Load it in a setup chunk:
 
-````quarto
+````markdown
 ```{{r}}
 #| include: false
 source("_extensions/mcanouil/typst-render/_resources/typst_define.R")
@@ -77,7 +77,7 @@ source("_extensions/mcanouil/typst-render/_resources/typst_define.R")
 The Python helper needs `IPython`.
 Load it the same way:
 
-````quarto
+````markdown
 ```{{python}}
 #| include: false
 import sys

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -44,11 +44,13 @@ The block then reaches the page as highlighted Typst source, with no figure besi
 
 Register a passthrough engine in a setup chunk, so that knitr hands the block back unchanged:
 
-````r
+````quarto
+```{{r}}
 #| include: false
 knitr::knit_engines$set(typst = function(options) {
   knitr::asis_output(paste0("\n```{typst}\n", paste(options[["code"]], collapse = "\n"), "\n```\n"))
 })
+```
 ````
 
 Per-block options, cross-reference labels, and captions all work after that.
@@ -65,20 +67,24 @@ There is no Julia helper, so this feature covers knitr and jupyter only.
 The R helper needs `rlang` and `jsonlite`.
 Load it in a setup chunk:
 
-```r
+````quarto
+```{{r}}
 #| include: false
 source("_extensions/mcanouil/typst-render/_resources/typst_define.R")
 ```
+````
 
 The Python helper needs `IPython`.
 Load it the same way:
 
-```python
+````quarto
+```{{python}}
 #| include: false
 import sys
 sys.path.insert(0, "_extensions/mcanouil/typst-render/_resources")
 from typst_define import typst_define
 ```
+````
 
 Call it wherever the values are ready:
 


### PR DESCRIPTION
The three setup snippets on the reference page showed only the chunk body, so a reader had to know which fence and options to wrap around it.
Each one now shows the whole Quarto cell, escaped with `{{r}}` and `{{python}}` so it is not executed.

The outer fences use `markdown`, which matches the embedded-cell examples in `docs/index.qmd`, `docs/examples.qmd`, and `example.qmd`, and gives the block syntax highlighting that a `quarto` class does not.